### PR TITLE
SDAP-32 CassandraProxy time series tiles to support time arrays

### DIFF
--- a/data-access/.gitignore
+++ b/data-access/.gitignore
@@ -34,6 +34,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.c
 
 # Distribution / packaging
 .Python

--- a/data-access/nexustiles/config/datastores.ini
+++ b/data-access/nexustiles/config/datastores.ini
@@ -17,4 +17,4 @@ host=localhost:8983
 core=nexustiles
 
 [datastore]
-store=s3
+store=cassandra

--- a/data-access/nexustiles/dao/CassandraProxy.pyx
+++ b/data-access/nexustiles/dao/CassandraProxy.pyx
@@ -17,7 +17,7 @@ import uuid
 from ConfigParser import NoOptionError
 from multiprocessing.synchronize import Lock
 
-import nexusproto.NexusContent_pb2 as nexusproto
+import nexusproto.DataTile_pb2 as nexusproto
 import numpy as np
 from cassandra.cqlengine import columns, connection, CQLEngineException
 from cassandra.cqlengine.models import Model

--- a/data-access/nexustiles/dao/CassandraProxy.pyx
+++ b/data-access/nexustiles/dao/CassandraProxy.pyx
@@ -103,9 +103,6 @@ class NexusTileData(Model):
             latitude_data = np.ma.masked_invalid(from_shaped_array(time_series_tile.latitude))
             longitude_data = np.ma.masked_invalid(from_shaped_array(time_series_tile.longitude))
 
-            # tile_data = self._to_standard_index(time_series_tile_data,
-            #                                     (len(time_data), len(latitude_data), len(longitude_data)))
-
             reshaped_array = np.ma.masked_all((len(time_data), len(latitude_data), len(longitude_data)))
             idx = np.arange(len(latitude_data))
             reshaped_array[:, idx, idx] = time_series_tile_data
@@ -115,7 +112,6 @@ class NexusTileData(Model):
             for meta_data_obj in time_series_tile.meta_data:
                 name = meta_data_obj.name
                 meta_array = np.ma.masked_invalid(from_shaped_array(meta_data_obj.meta_data))
-                # reshaped_meta_array = self._to_standard_index(meta_array, tile_data.shape)
 
                 reshaped_meta_array = np.ma.masked_all((len(time_data), len(latitude_data), len(longitude_data)))
                 idx = np.arange(len(latitude_data))

--- a/data-access/nexustiles/dao/CassandraProxy.pyx
+++ b/data-access/nexustiles/dao/CassandraProxy.pyx
@@ -99,19 +99,28 @@ class NexusTileData(Model):
             time_series_tile = self._get_nexus_tile().time_series_tile
 
             time_series_tile_data = np.ma.masked_invalid(from_shaped_array(time_series_tile.variable_data))
-            time_data = np.array([time_series_tile.time])
+            time_data = np.ma.masked_invalid(from_shaped_array(time_series_tile.time)).reshape(-1)
             latitude_data = np.ma.masked_invalid(from_shaped_array(time_series_tile.latitude))
             longitude_data = np.ma.masked_invalid(from_shaped_array(time_series_tile.longitude))
 
-            tile_data = self._to_standard_index(time_series_tile_data,
-                                                (len(time_data), len(latitude_data), len(longitude_data)))
+            # tile_data = self._to_standard_index(time_series_tile_data,
+            #                                     (len(time_data), len(latitude_data), len(longitude_data)))
 
+            reshaped_array = np.ma.masked_all((len(time_data), len(latitude_data), len(longitude_data)))
+            idx = np.arange(len(latitude_data))
+            reshaped_array[:, idx, idx] = time_series_tile_data
+            tile_data = reshaped_array
             # Extract the meta data
             meta_data = {}
             for meta_data_obj in time_series_tile.meta_data:
                 name = meta_data_obj.name
                 meta_array = np.ma.masked_invalid(from_shaped_array(meta_data_obj.meta_data))
-                reshaped_meta_array = self._to_standard_index(meta_array, tile_data.shape)
+                # reshaped_meta_array = self._to_standard_index(meta_array, tile_data.shape)
+
+                reshaped_meta_array = np.ma.masked_all((len(time_data), len(latitude_data), len(longitude_data)))
+                idx = np.arange(len(latitude_data))
+                reshaped_meta_array[:, idx, idx] = meta_array
+
                 meta_data[name] = reshaped_meta_array
 
             return latitude_data, longitude_data, time_data, tile_data, meta_data

--- a/data-access/nexustiles/dao/DynamoProxy.pyx
+++ b/data-access/nexustiles/dao/DynamoProxy.pyx
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import uuid
-import nexusproto.NexusContent_pb2 as nexusproto
+import nexusproto.DataTile_pb2 as nexusproto
 from nexusproto.serialization import from_shaped_array
 import numpy as np
 import boto3

--- a/data-access/nexustiles/dao/S3Proxy.pyx
+++ b/data-access/nexustiles/dao/S3Proxy.pyx
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import uuid
-import nexusproto.NexusContent_pb2 as nexusproto
+import nexusproto.DataTile_pb2 as nexusproto
 from nexusproto.serialization import from_shaped_array
 import numpy as np
 import boto3

--- a/data-access/nexustiles/dao/S3Proxy.pyx
+++ b/data-access/nexustiles/dao/S3Proxy.pyx
@@ -14,10 +14,12 @@
 # limitations under the License.
 
 import uuid
-import nexusproto.DataTile_pb2 as nexusproto
-from nexusproto.serialization import from_shaped_array
-import numpy as np
+
 import boto3
+import nexusproto.DataTile_pb2 as nexusproto
+import numpy as np
+from nexusproto.serialization import from_shaped_array
+
 
 class NexusTileData(object):
     __nexus_tile = None
@@ -127,7 +129,6 @@ class S3Proxy(object):
         self.__nexus_tile = None
 
     def fetch_nexus_tiles(self, *tile_ids):
-
         tile_ids = [uuid.UUID(str(tile_id)) for tile_id in tile_ids if
                     (isinstance(tile_id, str) or isinstance(tile_id, unicode))]
         res = []

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -21,10 +21,10 @@ from functools import wraps
 import numpy as np
 import numpy.ma as ma
 import pkg_resources
-from dao.CassandraProxy import CassandraProxy
-from dao.S3Proxy import S3Proxy
-from dao.DynamoProxy import DynamoProxy
-from dao.SolrProxy import SolrProxy
+import dao.CassandraProxy
+import dao.S3Proxy
+import dao.DynamoProxy
+import dao.SolrProxy
 from pytz import timezone
 from shapely.geometry import MultiPolygon, box
 
@@ -73,16 +73,16 @@ class NexusTileService(object):
         if not skipDatastore:
             datastore = self._config.get("datastore", "store")
             if datastore == "cassandra":
-                self._datastore = CassandraProxy(self._config)
+                self._datastore = dao.CassandraProxy.CassandraProxy(self._config)
             elif datastore == "s3":
-                self._datastore = S3Proxy(self._config)
+                self._datastore = dao.S3Proxy.S3Proxy(self._config)
             elif datastore == "dynamo":
-                self._datastore = DynamoProxy(self._config)
+                self._datastore = dao.DynamoProxy.DynamoProxy(self._config)
             else:
                 raise ValueError("Error reading datastore from config file")
 
         if not skipMetadatastore:
-            self._metadatastore = SolrProxy(self._config)
+            self._metadatastore = dao.SolrProxy.SolrProxy(self._config)
 
     def get_dataseries_list(self, simple=False):
         if simple:

--- a/data-access/requirements.txt
+++ b/data-access/requirements.txt
@@ -14,7 +14,7 @@ futures==3.1.1
 ipython==5.3.0
 ipython-genutils==0.2.0
 jmespath==0.9.3
-nexusproto==0.4
+nexusproto==1.0.0-SNAPSHOT
 numpy==1.11.1
 pathlib2==2.2.1
 pexpect==4.2.1

--- a/data-access/setup.py
+++ b/data-access/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         'cassandra-driver==3.5.0',
         'solrpy==0.9.7',
         'requests',
-        'nexusproto==0.4',
+        'nexusproto==1.0.0-SNAPSHOT',
         'shapely'
     ],
 

--- a/data-access/tests/nexustiles_test.py
+++ b/data-access/tests/nexustiles_test.py
@@ -68,6 +68,13 @@ core=nexustiles""")
         for tile in tiles:
             print tile.min_time
 
+    def test_time_series_tile(self):
+        tiles = self.tile_service.find_tiles_by_exact_bounds((-122.789, 45.837, -122.789, 45.837),
+                                                             "RAPID_WSWM_SWOT",
+                                                             1, time.time(), fetch_data=True)
+        for tile in tiles:
+            print tile.get_summary()
+
 
 # from nexustiles.model.nexusmodel import get_approximate_value_for_lat_lon
 # import numpy as np

--- a/data-access/tests/nexustiles_test.py
+++ b/data-access/tests/nexustiles_test.py
@@ -29,11 +29,14 @@ host=127.0.0.1
 keyspace=nexustiles
 local_datacenter=datacenter1
 protocol_version=3
-port=32769
+port=9042
 
 [solr]
-host=localhost:8986
-core=nexustiles""")
+host=localhost:8983
+core=nexustiles
+
+[datastore]
+store=cassandra""")
         cp = ConfigParser.RawConfigParser()
         cp.readfp(config)
 
@@ -69,9 +72,7 @@ core=nexustiles""")
             print tile.min_time
 
     def test_time_series_tile(self):
-        tiles = self.tile_service.find_tiles_by_exact_bounds((-122.789, 45.837, -122.789, 45.837),
-                                                             "RAPID_WSWM_SWOT",
-                                                             1, time.time(), fetch_data=True)
+        tiles = self.tile_service.find_tile_by_id("055c0b51-d0fb-3f39-b48a-4f762bf0c994")
         for tile in tiles:
             print tile.get_summary()
 


### PR DESCRIPTION
This PR alters the data-access library for time series tiles. It now expects time series tiles to have an array for their time attribute instead of a single value.