### PR TITLE
SDAP-123 Allow Jupyter image to configure nexus repo at build time.

### DIFF
--- a/docker/jupyter/Dockerfile
+++ b/docker/jupyter/Dockerfile
@@ -27,14 +27,18 @@ RUN pip install -r /tmp/requirements.txt && \
 
 ENV CHOWN_HOME_OPTS='-R'
 ENV REBUILD_CODE=true
+
+ARG APACHE_NEXUS=https://github.com/apache/incubator-sdap-nexus.git
+ARG APACHE_NEXUS_BRANCH=master
+
 RUN mkdir -p /home/jovyan/Quickstart && \
     mkdir -p /home/jovyan/nexuscli && \
     cd /home/jovyan/nexuscli && \
     git init && \
-    git remote add -f origin https://github.com/apache/incubator-sdap-nexus && \
+    git remote add -f origin ${APACHE_NEXUS} && \
     git config core.sparseCheckout true && \
     echo "client" >> .git/info/sparse-checkout && \
-    git pull origin master && \
+    git pull origin ${APACHE_NEXUS_BRANCH} && \
     cd client && \
     python setup.py install
 


### PR DESCRIPTION
I modified the Jupyter Docker image to enable the NEXUS repo and branch to use to be configured at build time.  The build syntax for this feature is as follows: 

docker build --build-arg APACHE_NEXUS=https://github.com/my-repo.git --build-arg APACHE_NEXUS_BRANCH=my-branch -t my-image-tag .