### PR TITLE
SDAP-138 Permission Denied Solr Image

### DIFF
--- a/docker/solr-single-node/Dockerfile
+++ b/docker/solr-single-node/Dockerfile
@@ -20,7 +20,14 @@ MAINTAINER Apache SDAP "dev@sdap.apache.org"
 USER root
 
 COPY create-core.sh /docker-entrypoint-initdb.d/create-core.sh
-RUN chown ${SOLR_USER}:${SOLR_GROUP} /docker-entrypoint-initdb.d/create-core.sh
+RUN echo "${SOLR_USER} ALL=(ALL) NOPASSWD: /usr/bin/cp -r /tmp/nexustiles/* ${SOLR_HOME}/nexustiles/" >> /etc/sudoers && \
+  echo "${SOLR_USER} ALL=(ALL) NOPASSWD: /usr/bin/chown -R ${SOLR_USER}\:${SOLR_GROUP} ${SOLR_HOME}/nexustiles" >> /etc/sudoers
+
+#cp -r /tmp/nexustiles/* ${SOLR_HOME}/nexustiles/
+#chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}/nexustiles
+#joe ALL=(ALL) NOPASSWD: /full/path/to/command ARG1 ARG2
+
+# RUN chown ${SOLR_USER}:${SOLR_GROUP} /docker-entrypoint-initdb.d/create-core.sh
 
 USER ${SOLR_USER}
 VOLUME ${SOLR_HOME}/nexustiles

--- a/docker/solr-single-node/create-core.sh
+++ b/docker/solr-single-node/create-core.sh
@@ -19,7 +19,7 @@ set -ex
 
 SOLR_HOME=${SOLR_HOME:=/opt/solr/server/solr/}
 mkdir -p ${SOLR_HOME}/nexustiles
-cp -r /tmp/nexustiles/* ${SOLR_HOME}/nexustiles/
-chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}/nexustiles
+sudo cp -r /tmp/nexustiles/* ${SOLR_HOME}/nexustiles/
+sudo chown -R ${SOLR_USER}:${SOLR_GROUP} ${SOLR_HOME}/nexustiles
 
 set +x

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -17,11 +17,11 @@ MAINTAINER Apache SDAP "dev@sdap.apache.org"
 
 USER root
 
-ENV SOLR_HOME=/opt/solr/server/solr/
+ENV SOLR_HOME=/opt/solr/server/solr
 
 RUN cd / && \
     apt-get update && \
-    apt-get -y install git && \
+    apt-get -y install git sudo && \
     rm -rf /var/lib/apt/lists/* && \
     git clone https://github.com/apache/incubator-sdap-nexus.git && \
     cp -r /incubator-sdap-nexus/data-access/config/schemas/solr/nexustiles /tmp/nexustiles && \

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -233,7 +233,7 @@ The ningester docker image runs a batch job that will ingest one granule. Here, 
 
   for g in `ls ${DATA_DIRECTORY} | awk "{print $1}"`
   do
-    docker run -d --name $(echo avhrr_$g | cut -d'-' -f 1) --network sdap-net -v ${NINGESTER_CONFIG}:/config/ -v ${DATA_DIRECTORY}/${g}:/data/${g} sdap/ningester:${VERSION} docker,solr,cassandra
+    docker run -d --name $(echo avhrr_$g | cut -d'-' -f 1) --network sdap-net -v ${NINGESTER_CONFIG}:/home/ningester/config/ -v ${DATA_DIRECTORY}/${g}:/home/ningester/data/${g} sdap/ningester:${VERSION} docker,solr,cassandra
     sleep 60
   done
 


### PR DESCRIPTION
When starting the solr-singlenode image for the first time with a host directory that does not exist usually causes a permission denied error. This PR should fix that issue.