### PR TITLE
SDAP-151 Determine parallelism automatically for Spark analytics

### DIFF
--- a/analysis/webservice/NexusHandler.py
+++ b/analysis/webservice/NexusHandler.py
@@ -320,8 +320,7 @@ class SparkHandler(NexusHandler):
 
     def _setQueryParams(self, ds, bounds, start_time=None, end_time=None,
                         start_year=None, end_year=None, clim_month=None,
-                        fill=-9999., spark_master=None, spark_nexecs=None,
-                        spark_nparts=None):
+                        fill=-9999.):
         self._ds = ds
         self._minLat, self._maxLat, self._minLon, self._maxLon = bounds
         self._startTime = start_time
@@ -330,10 +329,7 @@ class SparkHandler(NexusHandler):
         self._endYear = end_year
         self._climMonth = clim_month
         self._fill = fill
-        self._spark_master = spark_master
-        self._spark_nexecs = spark_nexecs
-        self._spark_nparts = spark_nparts
-
+        
     def _set_info_from_tile_set(self, nexus_tiles):
         ntiles = len(nexus_tiles)
         self.log.debug('Attempting to extract info from {0} tiles'.\
@@ -577,6 +573,13 @@ class SparkHandler(NexusHandler):
 
     def _create_nc_file(self, a, fname, varname, **kwargs):
         self._create_nc_file_latlon2d(a, fname, varname, **kwargs)
+
+    def _spark_nparts(self, nparts_requested):
+        max_parallelism = 128
+        num_partitions = min(nparts_requested if nparts_requested > 0
+                             else self._sc.defaultParallelism,
+                             max_parallelism)
+        return num_partitions
 
 
 def executeInitializers(config):

--- a/analysis/webservice/algorithms_spark/TimeSeriesSpark.py
+++ b/analysis/webservice/algorithms_spark/TimeSeriesSpark.py
@@ -153,13 +153,14 @@ class TimeSeriesHandlerImpl(SparkHandler):
         apply_seasonal_cycle_filter = request.get_apply_seasonal_cycle_filter(default=False)
         apply_low_pass_filter = request.get_apply_low_pass_filter()
 
-        spark_master, spark_nexecs, spark_nparts = request.get_spark_cfg()
-
         start_seconds_from_epoch = long((start_time - EPOCH).total_seconds())
         end_seconds_from_epoch = long((end_time - EPOCH).total_seconds())
 
-        return ds, bounding_polygon, start_seconds_from_epoch, end_seconds_from_epoch, \
-               apply_seasonal_cycle_filter, apply_low_pass_filter, spark_master, spark_nexecs, spark_nparts
+        nparts = request.get_nparts()
+
+        return ds, bounding_polygon, \
+            start_seconds_from_epoch, end_seconds_from_epoch, \
+            apply_seasonal_cycle_filter, apply_low_pass_filter, nparts
 
     def calc(self, request, **args):
         """
@@ -169,9 +170,10 @@ class TimeSeriesHandlerImpl(SparkHandler):
         :return:
         """
 
-        ds, bounding_polygon, start_seconds_from_epoch, end_seconds_from_epoch, \
-        apply_seasonal_cycle_filter, apply_low_pass_filter, spark_master, \
-        spark_nexecs, spark_nparts = self.parse_arguments(request)
+        (ds, bounding_polygon, start_seconds_from_epoch,
+         end_seconds_from_epoch, apply_seasonal_cycle_filter,
+         apply_low_pass_filter, nparts_requested) = \
+            self.parse_arguments(request)
 
         resultsRaw = []
 
@@ -194,11 +196,13 @@ class TimeSeriesHandlerImpl(SparkHandler):
             self.log.debug('Found {0} days in range'.format(ndays))
             for i, d in enumerate(daysinrange):
                 self.log.debug('{0}, {1}'.format(i, datetime.utcfromtimestamp(d)))
-            spark_nparts_needed = min(spark_nparts, ndays)
+            spark_nparts = determine_parallelism(ndays, nparts_requested)
 
+            print('Using {} partitions'.format(spark_nparts))
             the_time = datetime.now()
-            results, meta = spark_driver(daysinrange, bounding_polygon, shortName,
-                                         spark_nparts_needed=spark_nparts_needed, sc=self._sc)
+            results, meta = spark_driver(daysinrange, bounding_polygon,
+                                         shortName, spark_nparts=spark_nparts,
+                                         sc=self._sc)
             self.log.info(
                 "Time series calculation took %s for dataset %s" % (str(datetime.now() - the_time), shortName))
 
@@ -487,15 +491,24 @@ class TimeSeriesResults(NexusResults):
         return sio.getvalue()
 
 
-def spark_driver(daysinrange, bounding_polygon, ds, fill=-9999., spark_nparts_needed=1, sc=None):
+def determine_parallelism(ndays, nparts_requested):
+    max_parallelism = 128
+    days_per_partition = 24
+    num_partitions = min(nparts_requested if nparts_requested > 0
+                         else ndays / days_per_partition,
+                         max_parallelism)
+    return num_partitions
+
+
+def spark_driver(daysinrange, bounding_polygon, ds, fill=-9999.,
+                 spark_nparts=1, sc=None):
     nexus_tiles_spark = [(bounding_polygon.wkt, ds,
                           list(daysinrange_part), fill)
                          for daysinrange_part
-                         in np.array_split(daysinrange,
-                                           spark_nparts_needed)]
+                         in np.array_split(daysinrange, spark_nparts)]
 
     # Launch Spark computations
-    rdd = sc.parallelize(nexus_tiles_spark, spark_nparts_needed)
+    rdd = sc.parallelize(nexus_tiles_spark, spark_nparts)
     results = rdd.map(calc_average_on_day).collect()
     results = list(itertools.chain.from_iterable(results))
     results = sorted(results, key=lambda entry: entry["time"])

--- a/analysis/webservice/webmodel.py
+++ b/analysis/webservice/webmodel.py
@@ -51,7 +51,7 @@ class RequestParameters(object):
     ORDER = "lpOrder"
     PLOT_SERIES = "plotSeries"
     PLOT_TYPE = "plotType"
-    SPARK_CFG = "spark"
+    NPARTS = "nparts"
     METADATA_FILTER = "metadataFilter"
 
 
@@ -77,12 +77,6 @@ class NoDataException(NexusProcessingException):
 class DatasetNotFoundException(NexusProcessingException):
     def __init__(self, reason="Dataset not found"):
         NexusProcessingException.__init__(self, StandardNexusErrors.DATASET_MISSING, reason, code=404)
-
-
-class SparkConfig(object):
-    MAX_NUM_EXECS = 64
-    MAX_NUM_PARTS = 8192
-    DEFAULT = "local,1,1"
 
 
 class StatsComputeOptions(object):
@@ -149,7 +143,7 @@ class StatsComputeOptions(object):
     def get_plot_type(self, default="default"):
         raise Exception("Please implement")
 
-    def get_spark_cfg(self, default=SparkConfig.DEFAULT):
+    def get_nparts(self):
         raise Exception("Please implement")
 
 
@@ -343,25 +337,8 @@ class NexusRequestObject(StatsComputeOptions):
     def get_plot_type(self, default="default"):
         return self.get_argument(RequestParameters.PLOT_TYPE, default=default)
 
-    def get_spark_cfg(self, default=SparkConfig.DEFAULT):
-        arg = self.get_argument(RequestParameters.SPARK_CFG, default)
-        try:
-            master, nexecs, nparts = arg.split(',')
-        except:
-            raise ValueError('Invalid spark configuration: %s' % arg)
-        if master not in ("local", "yarn", "mesos"):
-            raise ValueError('Invalid spark master: %s' % master)
-        nexecs = int(nexecs)
-        if (nexecs < 1) or (nexecs > SparkConfig.MAX_NUM_EXECS):
-            raise ValueError('Invalid number of Spark executors: %d (must be between 1 and %d)' % (
-            nexecs, SparkConfig.MAX_NUM_EXECS))
-        nparts = int(nparts)
-        if (nparts < 1) or (nparts > SparkConfig.MAX_NUM_PARTS):
-            raise ValueError('Invalid number of Spark data partitions: %d (must be between 1 and %d)' % (
-            nparts, SparkConfig.MAX_NUM_PARTS))
-        if master == "local":
-            master = "local[%d]" % nexecs
-        return master, nexecs, nparts
+    def get_nparts(self):
+        return self.get_int_arg(RequestParameters.NPARTS, 0)
 
 
 class NexusResults:


### PR DESCRIPTION
The built-in NEXUS analytics timeSeriesSpark, timeAvgMapSpark, corrMapSpark, and climMapSpark got the desired parallelism from a job request parameter like "spark=mesos,16,32".  If that was omitted, we defaulted to "spark=local,1,1", which runs on a single core.  The new algorithms automatically determine the appropriate level of parallelism based on the job's Spark cluster configuration.  The job parameter called "spark" is no longer supported.  A new optional job parameter called "nparts" can be used to explicitly set the number of data partitions (e.g., "nparts=16").