### PR TITLE
SDAP-187 Unable to change cassandra port

### DIFF
--- a/analysis/webservice/algorithms/doms/DomsInitialization.py
+++ b/analysis/webservice/algorithms/doms/DomsInitialization.py
@@ -38,6 +38,7 @@ class DomsInitializer:
         domsconfig.readfp(pkg_resources.resource_stream(__name__, "domsconfig.ini"), filename='domsconfig.ini')
 
         cassHost = domsconfig.get("cassandra", "host")
+        cassPort = domsconfig.get("cassandra", "port")
         cassKeyspace = domsconfig.get("cassandra", "keyspace")
         cassDatacenter = domsconfig.get("cassandra", "local_datacenter")
         cassVersion = int(domsconfig.get("cassandra", "protocol_version"))
@@ -50,7 +51,7 @@ class DomsInitializer:
         dc_policy = DCAwareRoundRobinPolicy(cassDatacenter)
         token_policy = TokenAwarePolicy(dc_policy)
 
-        with Cluster([host for host in cassHost.split(',')], load_balancing_policy=token_policy,
+        with Cluster([host for host in cassHost.split(',')], port=cassPort, load_balancing_policy=token_policy,
                      protocol_version=cassVersion) as cluster:
             session = cluster.connect()
 

--- a/analysis/webservice/algorithms/doms/domsconfig.ini
+++ b/analysis/webservice/algorithms/doms/domsconfig.ini
@@ -1,5 +1,6 @@
 [cassandra]
 host=127.0.0.1
+port=9042
 keyspace=doms
 local_datacenter=datacenter1
 protocol_version=3

--- a/data-access/nexustiles/config/datastores.ini
+++ b/data-access/nexustiles/config/datastores.ini
@@ -1,5 +1,6 @@
 [cassandra]
 host=127.0.0.1
+port=9042
 keyspace=nexustiles
 local_datacenter=datacenter1
 protocol_version=3

--- a/docker/nexus-webapp/standalone/docker-entrypoint.sh
+++ b/docker/nexus-webapp/standalone/docker-entrypoint.sh
@@ -21,14 +21,14 @@ if [ -n "$TORNADO_HOST" ]; then
   sed -i "s/server.socket_host = .*/server.socket_host = '${TORNADO_HOST}'/g" ${NEXUS_SRC}/analysis/webservice/config/web.ini
 fi
 sed -i "s/host=127.0.0.1/host=$CASSANDRA_CONTACT_POINTS/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini && \
-sed -i "s/port=9042/host=$CASSANDRA_PORT/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini && \
+sed -i "s/port=9042/port=$CASSANDRA_PORT/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini && \
 sed -i "s/local_datacenter=.*/local_datacenter=$CASSANDRA_LOCAL_DATACENTER/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini && \
 sed -i "s/host=localhost:8983/host=$SOLR_URL_PORT/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini
 
 # DOMS
 sed -i "s/module_dirs=.*/module_dirs=webservice.algorithms,webservice.algorithms_spark,webservice.algorithms.doms/g" ${NEXUS_SRC}/analysis/webservice/config/web.ini && \
 sed -i "s/host=.*/host=$CASSANDRA_CONTACT_POINTS/g" ${NEXUS_SRC}/analysis/webservice/algorithms/doms/domsconfig.ini && \
- sed -i "s/port=.*/port=$CASSANDRA_PORT/g" ${NEXUS_SRC}/analysis/webservice/algorithms/doms/domsconfig.ini && \
+sed -i "s/port=.*/port=$CASSANDRA_PORT/g" ${NEXUS_SRC}/analysis/webservice/algorithms/doms/domsconfig.ini && \
 sed -i "s/local_datacenter=.*/local_datacenter=$CASSANDRA_LOCAL_DATACENTER/g" ${NEXUS_SRC}/analysis/webservice/algorithms/doms/domsconfig.ini
 
 cd ${NEXUS_SRC}/data-access

--- a/docker/nexus-webapp/standalone/docker-entrypoint.sh
+++ b/docker/nexus-webapp/standalone/docker-entrypoint.sh
@@ -21,12 +21,14 @@ if [ -n "$TORNADO_HOST" ]; then
   sed -i "s/server.socket_host = .*/server.socket_host = '${TORNADO_HOST}'/g" ${NEXUS_SRC}/analysis/webservice/config/web.ini
 fi
 sed -i "s/host=127.0.0.1/host=$CASSANDRA_CONTACT_POINTS/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini && \
+sed -i "s/port=9042/host=$CASSANDRA_PORT/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini && \
 sed -i "s/local_datacenter=.*/local_datacenter=$CASSANDRA_LOCAL_DATACENTER/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini && \
 sed -i "s/host=localhost:8983/host=$SOLR_URL_PORT/g" ${NEXUS_SRC}/data-access/nexustiles/config/datastores.ini
 
 # DOMS
 sed -i "s/module_dirs=.*/module_dirs=webservice.algorithms,webservice.algorithms_spark,webservice.algorithms.doms/g" ${NEXUS_SRC}/analysis/webservice/config/web.ini && \
 sed -i "s/host=.*/host=$CASSANDRA_CONTACT_POINTS/g" ${NEXUS_SRC}/analysis/webservice/algorithms/doms/domsconfig.ini && \
+ sed -i "s/port=.*/port=$CASSANDRA_PORT/g" ${NEXUS_SRC}/analysis/webservice/algorithms/doms/domsconfig.ini && \
 sed -i "s/local_datacenter=.*/local_datacenter=$CASSANDRA_LOCAL_DATACENTER/g" ${NEXUS_SRC}/analysis/webservice/algorithms/doms/domsconfig.ini
 
 cd ${NEXUS_SRC}/data-access


### PR DESCRIPTION
- DomsInitialization is now able to instantiate a Cluster object by using the "post" argument in method signature
- default port (9042) is added in both domsconfig.ini & datastores.ini
- running a Docker container with "-e CASSANDRA_PORT=<some_other_port>" will let the webapp contact the cassandra cluster