### PR TITLE
SDAP-206 remove pegged numpy version in nexuscli requirements.txt

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -8,6 +8,6 @@ numpy
 pdoc==0.3.2
 Pygments==2.2.0
 pytz==2017.2
-requests==2.18.4
+requests
 shapely==1.5.17
-urllib3==1.21.1
+urllib3

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -4,7 +4,7 @@ Mako==1.0.7
 markdown==2.4.1
 MarkupSafe==1.0
 nexuscli==1.0
-numpy==1.13.1
+numpy
 pdoc==0.3.2
 Pygments==2.2.0
 pytz==2017.2

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -4,10 +4,10 @@ Mako==1.0.7
 markdown==2.4.1
 MarkupSafe==1.0
 nexuscli==1.0
-numpy
+numpy==1.17.0
 pdoc==0.3.2
 Pygments==2.2.0
 pytz==2017.2
-requests
+requests==2.22.0
 shapely==1.5.17
-urllib3
+urllib3==1.25.3


### PR DESCRIPTION
This issue addresses https://issues.apache.org/jira/browse/SDAP-206