### PR TITLE
SDAP-154: Python 3

### DIFF
--- a/analysis/webservice/algorithms_spark/HofMoellerSpark.py
+++ b/analysis/webservice/algorithms_spark/HofMoellerSpark.py
@@ -324,7 +324,7 @@ def spark_driver(sc, latlon, tile_service_factory, nexus_tiles_spark, metrics_ca
 
     # Convert the tuples to dictionary entries and combine coordinates
     # with the same time stamp.  Here we have input key = (time)
-    results = list(results.values()).combineByKey(create_combiner, merge_value, merge_combiner).values().collect()
+    results = results.values().combineByKey(create_combiner, merge_value, merge_combiner).values().collect()
 
     reduce_duration = (datetime.now() - reduce_start).total_seconds()
     metrics_callback(reduce=reduce_duration)

--- a/analysis/webservice/webapp_livy.py
+++ b/analysis/webservice/webapp_livy.py
@@ -19,7 +19,7 @@ import logging
 import sys
 import os
 import pkg_resources
-from . import nexus_tornado.web
+from webservice import nexus_tornado
 from .nexus_tornado.options import define, options, parse_command_line
 from webservice.NexusLivyHandler import LivyHandler
 

--- a/data-access/requirements.txt
+++ b/data-access/requirements.txt
@@ -1,5 +1,5 @@
-cassandra-driver==3.5.0
-pysolr==3.7.0
+cassandra-driver==3.24.0
+pysolr==3.9.0
 requests
 nexusproto
 Shapely

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,7 +6,7 @@ rootWebpage:
 webapp:
   enabled: true
   distributed:
-    image: nexusjpl/nexus-webapp:distributed.0.3.0
+    image: nexusjpl/nexus-webapp:distributed.0.4.0
 
     ## Use any of the driver configuration options available at
     ## https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/docs/user-guide.md


### PR DESCRIPTION
[Apache Jira ticket](https://issues.apache.org/jira/browse/SDAP-154)
[Earthdata Jira ticket](https://bugs.earthdata.nasa.gov/browse/CDMS-46)

Made a few updates to address issues found while testing the Python3 changes.

- Fixed some import/casting issues in the code
- Upgraded `cassandra-driver` to 3.24.0 for compatibility with Python 3.8
- Upgraded `pysolr` to 3.24.0 for compatibility with Python 3.8
- Upgraded nexus-webapp version to `distributed.0.4.0` in helm/values.yaml, so the [new docker image](https://hub.docker.com/r/nexusjpl/nexus-webapp) is used in the kubernetes cluster. 

Note: There is another PR that is paired with this one [HERE](https://github.com/apache/incubator-sdap-nexusproto/pull/6) which these changes depend upon.