### PR TITLE
SDAP-305: Get current match up working with AVHRR OI data that is currently ingested in the bigdata cluster

### DIFF
--- a/analysis/setup.py
+++ b/analysis/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
         ('static', ['static/index.html'])
     ],
     platforms='any',
-    python_requires='~=2.7',
+    python_requires='~=3.7',
     classifiers=[
         'Development Status :: 1 - Pre-Alpha',
         'Intended Audience :: Developers',

--- a/analysis/webservice/algorithms/doms/DomsInitialization.py
+++ b/analysis/webservice/algorithms/doms/DomsInitialization.py
@@ -56,9 +56,9 @@ class DomsInitializer:
 
         if cassPolicy == 'DCAwareRoundRobinPolicy':
             dc_policy = DCAwareRoundRobinPolicy(cassDatacenter)
+            token_policy = TokenAwarePolicy(dc_policy)
         elif cassPolicy == 'WhiteListRoundRobinPolicy':
-            dc_policy = WhiteListRoundRobinPolicy([cassHost])
-        token_policy = TokenAwarePolicy(dc_policy)
+            token_policy = WhiteListRoundRobinPolicy([cassHost])
 
         if cassUsername and cassPassword:
             auth_provider = PlainTextAuthProvider(username=cassUsername, password=cassPassword)

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -131,8 +131,8 @@ class Matchup(NexusCalcSparkHandler):
     }
     singleton = True
 
-    def __init__(self, algorithm_config=None, sc=None):
-        NexusCalcSparkHandler.__init__(self, algorithm_config=algorithm_config, sc=sc)
+    def __init__(self, algorithm_config=None, sc=None, tile_service_factory=None):
+        NexusCalcSparkHandler.__init__(self, algorithm_config=algorithm_config, sc=sc, tile_service_factory=tile_service_factory)
         self.log = logging.getLogger(__name__)
 
     def parse_arguments(self, request):
@@ -227,6 +227,7 @@ class Matchup(NexusCalcSparkHandler):
                                                              sort=['tile_min_time_dt asc', 'tile_min_lon asc',
                                                                    'tile_min_lat asc'], rows=5000)]
 
+        self.log.debug('Found %s tile_ids', len(tile_ids))
         # Call spark_matchup
         self.log.debug("Calling Spark Driver")
         try:
@@ -601,6 +602,9 @@ def match_satellite_to_insitu(tile_ids, primary_b, matchup_b, parameter_b, tt_b,
                                                       parameter_b.value, rt_b.value, lonlat_proj, aeqd_proj) for tile_id
                         in tile_ids]
 
+    # Filter out 'None' matches
+    match_generators = [match for match in match_generators if match is not None]
+
     return chain(*match_generators)
 
 
@@ -612,6 +616,12 @@ def match_tile_to_point_generator(tile_service, tile_id, m_tree, edge_results, s
     # Load tile
     try:
         the_time = datetime.now()
+        tiles = tile_service.mask_tiles_to_polygon(wkt.loads(search_domain_bounding_wkt),
+                                                  tile_service.find_tile_by_id(tile_id))
+
+        if len(tiles) == 0:
+            print('Tile is empty after masking spatially. Skipping this tile.')
+            return
         tile = tile_service.mask_tiles_to_polygon(wkt.loads(search_domain_bounding_wkt),
                                                   tile_service.find_tile_by_id(tile_id))[0]
         print("%s Time to load tile %s" % (str(datetime.now() - the_time), tile_id))
@@ -677,10 +687,11 @@ def query_edge(dataset, variable, startTime, endTime, bbox, platform, depth_min,
               "platform": platform,
               "itemsPerPage": itemsPerPage, "startIndex": startIndex, "stats": str(stats).lower()}
 
+    dataset_url = edge_endpoints.getEndpointByName(dataset)['url']
     if session is not None:
-        edge_request = session.get(edge_endpoints.getEndpointByName(dataset)['url'], params=params)
+        edge_request = session.get(dataset_url, params=params)
     else:
-        edge_request = requests.get(edge_endpoints.getEndpointByName(dataset)['url'], params=params)
+        edge_request = requests.get(dataset_url, params=params)
 
     edge_request.raise_for_status()
     edge_response = json.loads(edge_request.text)

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -602,9 +602,6 @@ def match_satellite_to_insitu(tile_ids, primary_b, matchup_b, parameter_b, tt_b,
                                                       parameter_b.value, rt_b.value, lonlat_proj, aeqd_proj) for tile_id
                         in tile_ids]
 
-    # Filter out 'None' matches
-    match_generators = [match for match in match_generators if match is not None]
-
     return chain(*match_generators)
 
 

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -616,17 +616,13 @@ def match_tile_to_point_generator(tile_service, tile_id, m_tree, edge_results, s
     # Load tile
     try:
         the_time = datetime.now()
-        tiles = tile_service.mask_tiles_to_polygon(wkt.loads(search_domain_bounding_wkt),
-                                                  tile_service.find_tile_by_id(tile_id))
-
-        if len(tiles) == 0:
-            print('Tile is empty after masking spatially. Skipping this tile.')
-            return
-        tile = tiles[0]
+        tile = tile_service.mask_tiles_to_polygon(wkt.loads(search_domain_bounding_wkt),
+                                                  tile_service.find_tile_by_id(tile_id))[0]
         print("%s Time to load tile %s" % (str(datetime.now() - the_time), tile_id))
     except IndexError:
         # This should only happen if all measurements in a tile become masked after applying the bounding polygon
-        raise StopIteration
+        print('Tile is empty after masking spatially. Skipping this tile.')
+        return
 
     # Convert valid tile lat,lon tuples to UTM tuples
     the_time = datetime.now()

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -622,8 +622,7 @@ def match_tile_to_point_generator(tile_service, tile_id, m_tree, edge_results, s
         if len(tiles) == 0:
             print('Tile is empty after masking spatially. Skipping this tile.')
             return
-        tile = tile_service.mask_tiles_to_polygon(wkt.loads(search_domain_bounding_wkt),
-                                                  tile_service.find_tile_by_id(tile_id))[0]
+        tile = tiles[0]
         print("%s Time to load tile %s" % (str(datetime.now() - the_time), tile_id))
     except IndexError:
         # This should only happen if all measurements in a tile become masked after applying the bounding polygon

--- a/data-access/nexustiles/dao/CassandraProxy.py
+++ b/data-access/nexustiles/dao/CassandraProxy.py
@@ -175,14 +175,15 @@ class CassandraProxy(object):
     def __open(self):
         if self.__cass_dc_policy == 'DCAwareRoundRobinPolicy':
             dc_policy = DCAwareRoundRobinPolicy(self.__cass_local_DC)
+            token_policy = TokenAwarePolicy(dc_policy)
         elif self.__cass_dc_policy == 'WhiteListRoundRobinPolicy':
-            dc_policy = WhiteListRoundRobinPolicy([self.__cass_url])
+            token_policy = WhiteListRoundRobinPolicy([self.__cass_url])
 
         if self.__cass_username and self.__cass_password:
             auth_provider = PlainTextAuthProvider(username=self.__cass_username, password=self.__cass_password)
         else:
             auth_provider = None
-        token_policy = TokenAwarePolicy(dc_policy)
+
         connection.setup([host for host in self.__cass_url.split(',')], self.__cass_keyspace,
                          protocol_version=self.__cass_protocol_version, load_balancing_policy=token_policy,
                          port=self.__cass_port,

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -310,7 +310,7 @@ class NexusTileService(object):
                                       fetch_data=False, rows=len(tile_ids))
         polys = []
         for tile in tiles:
-            polys.append(box(tile.bbox.min_lon, tile.bbox.min_lat, tile.bbox.max_lon, tile.bbox.max_lat))
+            polys.append(box(tile.bbox.min_lon[0], tile.bbox.min_lat[0], tile.bbox.max_lon[0], tile.bbox.max_lat[0]))
         return box(*MultiPolygon(polys).bounds)
 
     def get_min_time(self, tile_ids, ds=None):

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -310,7 +310,7 @@ class NexusTileService(object):
                                       fetch_data=False, rows=len(tile_ids))
         polys = []
         for tile in tiles:
-            polys.append(box(tile.bbox.min_lon[0], tile.bbox.min_lat[0], tile.bbox.max_lon[0], tile.bbox.max_lat[0]))
+            polys.append(box(tile.bbox.min_lon, tile.bbox.min_lat, tile.bbox.max_lon, tile.bbox.max_lat))
         return box(*MultiPolygon(polys).bounds)
 
     def get_min_time(self, tile_ids, ds=None):
@@ -460,9 +460,21 @@ class NexusTileService(object):
                 pass
 
             try:
-                tile.bbox = BBox(
-                    solr_doc['tile_min_lat'], solr_doc['tile_max_lat'],
-                    solr_doc['tile_min_lon'], solr_doc['tile_max_lon'])
+                min_lat = solr_doc['tile_min_lat']
+                min_lon = solr_doc['tile_min_lon']
+                max_lat = solr_doc['tile_max_lat']
+                max_lon = solr_doc['tile_max_lon']
+
+                if isinstance(min_lat, list):
+                    min_lat = min_lat[0]
+                if isinstance(min_lon, list):
+                    min_lon = min_lon[0]
+                if isinstance(max_lat, list):
+                    max_lat = max_lat[0]
+                if isinstance(max_lon, list):
+                    max_lon = max_lon[0]
+
+                tile.bbox = BBox(min_lat, max_lat, min_lon, max_lon)
             except KeyError:
                 pass
 


### PR DESCRIPTION
[Jira ticket](https://issues.apache.org/jira/browse/SDAP-305)

In this branch, I've made the necessary fixes to get matchup working on AVHRR OI data. 

Sample request:

```sh
curl --request GET 'localhost:8083/match_spark?primary=avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020&startTime=1442102400&endTime=1442288800&tt=86400&rt=1000&b=-67.43499976462817,60.39585573909287,-50.681836983854154,76.72666987833477&platforms=1,2,3,4,5,6,7,8,9&parameter=sst&depthMin=0&depthMax=5&matchOnce=true&matchup=icoads'
```

Response:

```json
{
    "executionId": "ca33871b-db76-492c-bc43-bbd7d4bfea7e",
    "data": [
        {
            "sea_water_temperature": 276.22998046875,
            "sea_water_temperature_depth": 0,
            "sea_water_salinity": null,
            "sea_water_salinity_depth": null,
            "wind_speed": null,
            "wind_direction": null,
            "wind_u": null,
            "wind_v": null,
            "platform": "orbiting satellite",
            "device": "radiometers",
            "x": "-62.875",
            "y": "75.125",
            "point": "Point(-62.875 75.125)",
            "time": 1442102400,
            "fileurl": "20150913120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.0.nc",
            "id": "38e752cf-72bf-387e-8641-8f45d11b32ee[[0, 0, 18]]",
            "source": "avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020",
            "matches": [
                {
                    "sea_water_temperature": 3.2,
                    "sea_water_temperature_depth": null,
                    "sea_water_salinity": null,
                    "sea_water_salinity_depth": null,
                    "wind_speed": null,
                    "wind_direction": null,
                    "wind_u": null,
                    "wind_v": null,
                    "platform": "drifting surface float",
                    "device": null,
                    "x": "-62.88",
                    "y": "75.13",
                    "point": "Point(-62.88 75.13)",
                    "time": 1442124000,
                    "fileurl": null,
                    "id": "LCAHED",
                    "source": "icoads"
                }
            ]
        },
        {
            "sea_water_temperature": 276.1499938964844,
            "sea_water_temperature_depth": 0,
            "sea_water_salinity": null,
            "sea_water_salinity_depth": null,
            "wind_speed": null,
            "wind_direction": null,
            "wind_u": null,
            "wind_v": null,
            "platform": "orbiting satellite",
            "device": "radiometers",
            "x": "-62.875",
            "y": "75.125",
            "point": "Point(-62.875 75.125)",
            "time": 1442188800,
            "fileurl": "20150914120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.0.nc",
            "id": "6ba8741b-4eb8-30f6-9470-3ae2b8fa5f63[[0, 0, 18]]",
            "source": "avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020",
            "matches": [
                {
                    "sea_water_temperature": 3.2,
                    "sea_water_temperature_depth": null,
                    "sea_water_salinity": null,
                    "sea_water_salinity_depth": null,
                    "wind_speed": null,
                    "wind_direction": null,
                    "wind_u": null,
                    "wind_v": null,
                    "platform": "drifting surface float",
                    "device": null,
                    "x": "-62.88",
                    "y": "75.13",
                    "point": "Point(-62.88 75.13)",
                    "time": 1442124000,
                    "fileurl": null,
                    "id": "LCAHED",
                    "source": "icoads"
                }
            ]
        }
    ],
    "params": {
        "primary": "avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020",
        "matchup": "icoads",
        "startTime": 1442102400,
        "endTime": 1442288800,
        "bbox": "-67.43499976462817,60.39585573909287,-50.681836983854154,76.72666987833477",
        "timeTolerance": 86400,
        "radiusTolerance": 1000.0,
        "platforms": "1,2,3,4,5,6,7,8,9",
        "parameter": "sst",
        "depthMin": 0.0,
        "depthMax": 5.0
    },
    "bounds": {},
    "count": null,
    "details": {
        "timeToComplete": 22,
        "numInSituRecords": 0,
        "numInSituMatched": 2,
        "numGriddedChecked": 0,
        "numGriddedMatched": 2
    }
}
```

---

I ran these tests using `dc_policy=WhiteListRoundRobinPolicy`.
