### PR TITLE
make chart work with pre-existing data-volume (pvc)

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -32,9 +32,11 @@ The data volume which is used in both the Collection Manager and the Granule Ing
     server: {{ .Values.ingestion.granules.nfsServer }}
     path: {{ .Values.ingestion.granules.path }}
   {{- else }}
+  {{- if .Values.ingestion.granules.path -}}
   hostPath:
     path: {{ .Values.ingestion.granules.path }}
-{{- end }}
+  {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,7 +29,7 @@ ingestion:
 
   granuleIngester:
     replicas: 2
-    image: nexusjpl/granule-ingester:0.1.5
+    image: nexusjpl/granule-ingester:0.1.6
 
     ## cpu refers to both request and limit
     cpu: 1
@@ -38,7 +38,7 @@ ingestion:
     memory: 1Gi
 
   collectionManager:
-    image: nexusjpl/collection-manager:0.1.5
+    image: nexusjpl/collection-manager:0.1.6
 
     ## cpu refers to both request and limit
     cpu: 0.5


### PR DESCRIPTION
In this case the `path` becomes optional

This PR also uses the upgrades granule-ingester and collection-manager components (0.1.6)