### PR TITLE
SDAP-308 Fixed deletebyquery.py to be compatible with Python 3

### DIFF
--- a/tools/deletebyquery/deletebyquery.py
+++ b/tools/deletebyquery/deletebyquery.py
@@ -105,12 +105,12 @@ def delete_by_query(args):
 
 
 def confirm_delete(num_found):
-    do_continue = eval(input(
-        "This action will delete %s record(s) from SOLR and Cassandra. Are you sure you want to Continue? y/n: " % num_found))
+    do_continue = input(
+        "This action will delete %s record(s) from SOLR and Cassandra. Are you sure you want to Continue? y/n: " % num_found)
 
     while do_continue not in ['y', 'n']:
-        do_continue = eval(input(
-            "This action will delete %s record(s) from SOLR and Cassandra. Are you sure you want to Continue? y/n: " % num_found))
+        do_continue = input(
+            "This action will delete %s record(s) from SOLR and Cassandra. Are you sure you want to Continue? y/n: " % num_found)
 
     return do_continue == 'y'
 
@@ -124,10 +124,10 @@ def check_query(query):
         logging.info("Query returned 0 results")
         return False
 
-    do_continue = eval(input("Query found %s matching documents. Continue? [y]/n/(s)ample: " % num_found))
+    do_continue = input("Query found %s matching documents. Continue? [y]/n/(s)ample: " % num_found)
 
     while do_continue not in ['y', 'n', 's', '']:
-        do_continue = eval(input("Query found %s matching documents. Continue? [y]/n/(s)ample: " % num_found))
+        do_continue = input("Query found %s matching documents. Continue? [y]/n/(s)ample: " % num_found)
 
     if do_continue == 'y' or do_continue == '':
         return True

--- a/tools/deletebyquery/requirements.txt
+++ b/tools/deletebyquery/requirements.txt
@@ -1,1 +1,1 @@
-solrcloudpy==2.4.1
+solrcloudpy==4.0.1


### PR DESCRIPTION
Updated solrcloudpy dependency and removed eval so that deletebyquery tool works with Python 3.

Tested this locally and confirmed input works.

Before the change:

```
Query found 100254 matching documents. Continue? [y]/n/(s)ample: n
Traceback (most recent call last):
  File "/Users/nchung/PycharmProjects/incubator-sdap-nexus/tools/deletebyquery/deletebyquery.py", line 269, in <module>
    delete_by_query(the_args)
  File "/Users/nchung/PycharmProjects/incubator-sdap-nexus/tools/deletebyquery/deletebyquery.py", line 92, in delete_by_query
    if check_query(query):
  File "/Users/nchung/PycharmProjects/incubator-sdap-nexus/tools/deletebyquery/deletebyquery.py", line 127, in check_query
    do_continue = eval(input("Query found %s matching documents. Continue? [y]/n/(s)ample: " % num_found))
  File "<string>", line 1, in <module>
NameError: name 'n' is not defined
```

After the change:

```
Query found 100254 matching documents. Continue? [y]/n/(s)ample: n
2021-05-18T15:37:34 INFO:root:  Exiting
```

