### PR TITLE
Added missing tile_service_factory param to NexusCalcHandlers endpoints

### DIFF
--- a/analysis/webservice/algorithms/ColorBarHandler.py
+++ b/analysis/webservice/algorithms/ColorBarHandler.py
@@ -58,8 +58,8 @@ class ColorBarCalcHandler(BaseHandler):
     }
     singleton = True
 
-    def __init__(self):
-        BaseHandler.__init__(self)
+    def __init__(self, tile_service_factory):
+        BaseHandler.__init__(self, tile_service_factory)
 
     def __get_dataset_minmax(self, ds, dataTime):
         dataTimeStart = dataTime - 86400.0  # computeOptions.get_datetime_arg("t", None)

--- a/analysis/webservice/algorithms/MapFetchHandler.py
+++ b/analysis/webservice/algorithms/MapFetchHandler.py
@@ -91,8 +91,8 @@ class MapFetchCalcHandler(BaseHandler):
 
     NO_DATA_IMAGE = None
 
-    def __init__(self):
-        BaseHandler.__init__(self)
+    def __init__(self, tile_service_factory):
+        BaseHandler.__init__(self, tile_service_factory)
 
     @staticmethod
     def __tile_to_image(img_data, tile, min, max, table, x_res, y_res):

--- a/analysis/webservice/algorithms/doms/DatasetListQuery.py
+++ b/analysis/webservice/algorithms/doms/DatasetListQuery.py
@@ -34,8 +34,8 @@ class DomsDatasetListQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     params = {}
     singleton = True
 
-    def __init__(self):
-        BaseHandler.__init__(self)
+    def __init__(self, tile_service_factory):
+        BaseHandler.__init__(self, tile_service_factory=tile_service_factory)
 
     def getFacetsForInsituSource(self, source):
         url = source["url"]

--- a/analysis/webservice/algorithms/doms/MetadataQuery.py
+++ b/analysis/webservice/algorithms/doms/MetadataQuery.py
@@ -32,8 +32,8 @@ class DomsMetadataQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     params = {}
     singleton = True
 
-    def __init__(self):
-        BaseHandler.__init__(self)
+    def __init__(self, tile_service_factory):
+        BaseHandler.__init__(self, tile_service_factory)
 
     def calc(self, computeOptions, **args):
 

--- a/analysis/webservice/algorithms/doms/StatsQuery.py
+++ b/analysis/webservice/algorithms/doms/StatsQuery.py
@@ -27,8 +27,8 @@ class DomsStatsQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     params = {}
     singleton = True
 
-    def __init__(self):
-        BaseHandler.__init__(self)
+    def __init__(self, tile_service_factory):
+        BaseHandler.__init__(self, tile_service_factory)
 
     def calc(self, computeOptions, **args):
         source = computeOptions.get_argument("source", None)

--- a/analysis/webservice/algorithms/doms/ValuesQuery.py
+++ b/analysis/webservice/algorithms/doms/ValuesQuery.py
@@ -33,8 +33,8 @@ class DomsValuesQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     params = {}
     singleton = True
 
-    def __init__(self):
-        BaseHandler.__init__(self)
+    def __init__(self, tile_service_factory):
+        BaseHandler.__init__(self, tile_service_factory)
 
     def calc(self, computeOptions, **args):
         source = computeOptions.get_argument("source", None)


### PR DESCRIPTION
While looking through logs, I noticed some of the doms endpoints were leading to the following errors:

```
2021-05-23T16:11:03 - nexus - INFO - Received request GET /domsvalues (10.244.1.177)
2021-05-23T16:11:03 - tornado.application - ERROR - Uncaught exception GET /domsvalues (10.244.1.177)
HTTPServerRequest(protocol='http', host='mycluster', method='GET', uri='/domsvalues', version='HTTP/1.1', remote_ip='10.244.1.177')
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/tornado/web.py", line 1704, in _execute
    result = await result
  File "/opt/conda/lib/python3.8/site-packages/tornado/gen.py", line 234, in wrapper
    yielded = ctx_run(next, result)
  File "/opt/conda/lib/python3.8/site-packages/nexusanalysis-1.6-py3.8.egg/webservice/nexus_tornado/request/handlers/NexusRequestHandler.py", line 30, in get
    instance = self.__clazz(**self._clazz_init_args)
TypeError: __init__() got an unexpected keyword argument 'tile_service_factory'
```

This is because of the missing `tile_service_factory` param on some of the NexusCalcHandler endpoints. Added that param to the following endpoints:

- `/colorbar`
- `/map`
- `/domsstats`
- `/domsmetadata`
- `/domsvalues`
- `/domslist`

All of the /doms* endpoints lead to 500 errors, here are the results when testing locally:


```
{{big_data_url}}/domslist
```

```json
{
    "executionId": "None",
    "data": {
        "satellite": [
            {
                "shortName": "20210329-0830-T11SPC",
                "title": "20210329-0830-T11SPC",
                "tileCount": 14884,
                "metadata": null
            },
            {
                "shortName": "20210329-0946-T11SPC",
                "title": "20210329-0946-T11SPC",
                "tileCount": 14884,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_ETAN_latlon",
                "title": "ECCO_v4_r4_ETAN_latlon",
                "tileCount": 89856,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_EVELMASS_latlon",
                "title": "ECCO_v4_r4_EVELMASS_latlon",
                "tileCount": 4492739,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_EXFqnet_latlon",
                "title": "ECCO_v4_r4_EXFqnet_latlon",
                "tileCount": 89856,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_EXFtaue_latlon",
                "title": "ECCO_v4_r4_EXFtaue_latlon",
                "tileCount": 89856,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_EXFtaun_latlon",
                "title": "ECCO_v4_r4_EXFtaun_latlon",
                "tileCount": 89856,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_OBPNOPAB_latlon",
                "title": "ECCO_v4_r4_OBPNOPAB_latlon",
                "tileCount": 89855,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_OBP_latlon",
                "title": "ECCO_v4_r4_OBP_latlon",
                "tileCount": 86688,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_PHIBOT_latlon",
                "title": "ECCO_v4_r4_PHIBOT_latlon",
                "tileCount": 89856,
                "metadata": null
            },
            {
                "shortName": "ECCO_v4_r4_SALT_SURFACE_latlon",
                "title": "ECCO_v4_r4_SALT_SURFACE_latlon",
                "tileCount": 89856,
                "metadata": null
            },
...
}
```

```
{{big_data_url}}/domsvalues?source=spurs&startTime=2012-09-13T00:00:00Z&endTime=2012-09-14T00:00:00Z&tt=86400&rt=1000&b=-51.033794185130915,19.428037510477424,-37.237071895081726,33.787891322569436&platforms=1,2,3,4,5,6,7,8,9&depthMin=0.0&depthMax=5.0
```

```json
{
    "executionId": "None",
    "data": [
        {
            "x": -38.03150177,
            "y": 24.5655002594,
            "source": "spurs",
            "time": 1347528191000.0,
            "device": "CTD",
            "platform": "ship",
            "depth": 2.98077630997
        },
        {
            "x": -38.03150177,
            "y": 24.5655002594,
            "source": "spurs",
            "time": 1347528191000.0,
            "device": "CTD",
            "platform": "ship",
            "depth": 3.97435855865
        },
        {
            "x": -38.03150177,
            "y": 24.5655002594,
            "source": "spurs",
            "time": 1347528191000.0,
            "device": "CTD",
            "platform": "ship",
            "depth": 4.96793651581
        },
...
}
```

```
{{big_data_url}}/domsmetadata?dataset=samos
```

```json
{
    "executionId": "None",
    "data": {
        "Projects": [
            {
                "ShortName": "",
                "LongName": "SAMOS"
            }
        ],
        "SpatialExtent": {
            "SpatialCoverageType": "HORIZONTAL",
            "HorizontalSpatialDomain": {
                "Geometry": {
                    "CoordinateSystem": "",
                    "BoundingRectangles": [
                        {
                            "WestBoundingCoordinate": -180,
                            "NorthBoundingCoordinate": 88.45,
                            "EastBoundingCoordinate": 180,
                            "SouthBoundingCoordinate": -88.5
                        }
                    ]
                }
            },
            "GranuleSpatialRepresentation": ""
        },
        "Distributions": [
            {
                "DistributionFormat": "NetCDF"
            }
        ],
        "ScienceKeywords": [
            {
                "Category": "Earth Science",
                "Topic": "Oceans",
                "Term": "Ocean Temperature",
                "VariableLevel1": "Sea Surface Temperature",
                "DetailedVariable": ""
            },
            {
                "Category": "Earth Science",
                "Topic": "Oceans",
                "Term": "Salinity/Density",
                "VariableLevel1": "Salinity",
                "DetailedVariable": ""
            },
            {
                "Category": "Earth Science",
                "Topic": "Oceans",
                "Term": "Ocean Winds",
                "VariableLevel1": "Surface Winds",
                "DetailedVariable": "Surface Wind Speed"
            }
        ],
        "TemporalExtents": [
            {
                "RangeDateTimes": [
                    {
                        "BeginningDateTime": "2005-05-09T00:00:00Z"
                    }
                ]
            }
        ],
        "ProcessingLevel": {
            "Id": "Intermediate"
        },
        "ShortName": "SAMOS",
        "EntryTitle": "Shipboard Automated Meteorological and Oceanographic System",
        "RelatedUrls": [
            {
                "Description": "OPeNDAP",
                "Relation": [
                    "GET DATA"
                ],
                "URLs": [
                    "x"
                ]
            }
        ],
        "DataDates": [
            {
                "Date": "2016-06-06T09:11:54Z",
                "Type": "UPDATE"
            }
        ],
        "Abstract": "The SAMOS initiative provides routine access to 1-minute sampling interval, high-quality marine meteorological and near-surface oceanographic observations collected by automated instrumentation on research vessels.",
        "Version": "1",
        "SpatialKeywords": [
            "Global"
        ],
        "Platforms": [],
        "CollectionCitations": [
            {
                "DOI": "10.7289/V5QJ7F8R"
            }
        ],
        "AncillaryKeywords": [
            "marine meteorology",
            "research vessels",
            "underway data",
            "sea temperature",
            "salinity",
            "winds",
            "in situ"
        ],
        "AdditionalAttributes": []
    },
    "params": null,
    "bounds": {},
    "count": null,
    "details": null
}
```

```
{{big_data_url}}/domsstats?source=spurs&startTime=2012-09-13T00:00:00Z&endTime=2012-09-14T00:00:00Z&tt=86400&rt=1000&b=-51.033794185130915,19.428037510477424,-37.237071895081726,33.787891322569436&platforms=1,2,3,4,5,6,7,8,9&depthMin=0.0&depthMax=5.0
```

```json
{
    "executionId": "None",
    "data": {},
    "params": {
        "source": "spurs",
        "startTime": null,
        "endTime": null,
        "bbox": "-51.033794185130915,19.428037510477424,-37.237071895081726,33.787891322569436",
        "timeTolerance": 86400.0,
        "depthMin": 0.0,
        "depthMax": 5.0,
        "radiusTolerance": 1000.0,
        "platforms": "1,2,3,4,5,6,7,8,9"
    },
    "bounds": {
        "xmin": 180,
        "xmax": -180,
        "ymin": 90,
        "ymax": -90
    },
    "count": 163989,
    "details": {}
}
```

*Note: was unable to test /map and /colorbar on either localhost or bigdata.*