### PR TITLE
SDAP-338: Update match up implementation to support multi-variable tiles

### DIFF
--- a/analysis/tests/algorithms_spark/test_matchup.py
+++ b/analysis/tests/algorithms_spark/test_matchup.py
@@ -282,7 +282,8 @@ def test_match_satellite_to_insitu(test_dir, test_tile, test_matchup_args):
     with secondary point (5, 15) and primary point (20, 0) should match
     with (18, 3)
     """
-    test_tile.var_names = ['sea_surface_temperature']
+    test_tile.var_names = ['sst']
+    test_tile.standard_names = ['sea_surface_temperature']
     test_tile.latitudes = np.array([0, 20], dtype=np.float32)
     test_tile.longitudes = np.array([0, 20], dtype=np.float32)
     test_tile.times = [1627490285]
@@ -357,13 +358,17 @@ def test_match_satellite_to_insitu(test_dir, test_tile, test_matchup_args):
             else:
                 assert matchup_result[0][1].data[0].variable_value == 30.0
                 assert matchup_result[1][1].data[0].variable_value == 10.0
-                assert matchup_result[0][1].data[0].variable_name == 'sea_surface_temperature'
-                assert matchup_result[1][1].data[0].variable_name == 'sea_surface_temperature'
+                assert matchup_result[0][1].data[0].variable_name == 'sst'
+                assert matchup_result[0][1].data[0].cf_variable_name == 'sea_surface_temperature'
+                assert matchup_result[1][1].data[0].variable_name == 'sst'
+                assert matchup_result[1][1].data[0].cf_variable_name == 'sea_surface_temperature'
             # Check that the satellite points have the expected values
             assert matchup_result[0][0].data[0].variable_value == 21.0
             assert matchup_result[1][0].data[0].variable_value == 31.0
-            assert matchup_result[0][0].data[0].variable_name == 'sea_surface_temperature'
-            assert matchup_result[1][0].data[0].variable_name == 'sea_surface_temperature'
+            assert matchup_result[0][0].data[0].variable_name == 'sst'
+            assert matchup_result[0][0].data[0].cf_variable_name == 'sea_surface_temperature'
+            assert matchup_result[1][0].data[0].variable_name == 'sst'
+            assert matchup_result[1][0].data[0].cf_variable_name == 'sea_surface_temperature'
 
         insitu_matchup_result = list(generator)
         validate_matchup_result(insitu_matchup_result, insitu_matchup=True)
@@ -380,7 +385,8 @@ def test_match_satellite_to_insitu(test_dir, test_tile, test_matchup_args):
         points = [wkt.loads(result['point']) for result in edge_json['results']]
 
         matchup_tile = Tile()
-        matchup_tile.var_names = ['sea_surface_temperature']
+        matchup_tile.var_names = ['sst']
+        matchup_tile.standard_names = ['sea_surface_temperature']
         matchup_tile.latitudes = np.array([point.y for point in points], dtype=np.float32)
         matchup_tile.longitudes = np.array([point.x for point in points], dtype=np.float32)
         matchup_tile.times = [edge_json['results'][0]['time']]
@@ -415,6 +421,7 @@ def test_multi_variable_matchup(test_dir, test_tile, test_matchup_args):
     ])
     test_tile.is_multi = True
     test_tile.var_names = ['wind_speed', 'wind_dir']
+    test_tile.standard_names = ['wind_speed', 'wind_direction']
     test_matchup_args['tile_service_factory'] = setup_mock_tile_service(test_tile)
 
     with mock.patch(
@@ -466,6 +473,7 @@ def test_multi_variable_satellite_to_satellite_matchup(test_dir, test_tile, test
     ])
     test_tile.is_multi = True
     test_tile.var_names = ['wind_speed', 'wind_dir']
+    test_tile.standard_names = ['wind_speed', 'wind_direction']
     test_matchup_args['tile_service_factory'] = setup_mock_tile_service(test_tile)
 
     with mock.patch(
@@ -478,7 +486,8 @@ def test_multi_variable_satellite_to_satellite_matchup(test_dir, test_tile, test
         points = [wkt.loads(result['point']) for result in edge_json['results']]
 
         matchup_tile = Tile()
-        matchup_tile.var_names = ['sea_surface_temperature', 'wind_dir']
+        matchup_tile.var_names = ['sst', 'wind_dir']
+        matchup_tile.standard_names = ['sea_surface_temperature', 'wind_direction']
         matchup_tile.latitudes = np.array([point.y for point in points], dtype=np.float32)
         matchup_tile.longitudes = np.array([point.x for point in points], dtype=np.float32)
         matchup_tile.times = [edge_json['results'][0]['time']]

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -385,12 +385,12 @@ class DomsPoint(object):
             data_vals = [nexus_point.data_vals]
 
         data = []
-        for val, name, standard_name in zip(data_vals, tile.var_names, tile.standard_names):
-            if val:
+        for data_val, variable in zip(data_vals, tile.variables):
+            if data_val:
                 data.append(DataPoint(
-                    variable_name=name,
-                    variable_value=val,
-                    cf_variable_name=standard_name
+                    variable_name=variable.variable_name,
+                    variable_value=data_val,
+                    cf_variable_name=variable.standard_name
                 ))
         point.data = data
 
@@ -479,16 +479,15 @@ class DomsPoint(object):
 
 
         # This is for satellite secondary points
-        if 'var_names' in edge_point and 'var_values' in edge_point:
+        if 'variables' in edge_point:
 
             data.extend([DataPoint(
-                variable_name=var_name,
+                variable_name=variable.variable_name,
                 variable_value=var_value,
-                cf_variable_name=standard_name
-            ) for var_name, var_value, standard_name in zip(
-                edge_point['var_names'],
+                cf_variable_name=variable.standard_name
+            ) for var_value, variable in zip(
                 edge_point['var_values'],
-                edge_point['var_standard_names']
+                edge_point['variables']
             ) if var_value])
         point.data = data
 
@@ -617,9 +616,8 @@ def tile_to_edge_points(tile):
             'platform': None,
             'device': None,
             'fileurl': tile.granule,
-            'var_names': tile.var_names,
-            'var_values': data,
-            'var_standard_names': tile.standard_names
+            'variables': tile.variables,
+            'var_values': data
         }
         edge_points.append(edge_point)
     return edge_points

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -386,11 +386,12 @@ class DomsPoint(object):
 
         data = []
         for val, name, standard_name in zip(data_vals, tile.var_names, tile.standard_names):
-            data.append(DataPoint(
-                variable_name=name,
-                variable_value=val,
-                cf_variable_name=standard_name
-            ))
+            if val:
+                data.append(DataPoint(
+                    variable_name=name,
+                    variable_value=val,
+                    cf_variable_name=standard_name
+                ))
         point.data = data
 
         try:
@@ -479,6 +480,7 @@ class DomsPoint(object):
 
         # This is for satellite secondary points
         if 'var_names' in edge_point and 'var_values' in edge_point:
+
             data.extend([DataPoint(
                 variable_name=var_name,
                 variable_value=var_value,
@@ -487,7 +489,7 @@ class DomsPoint(object):
                 edge_point['var_names'],
                 edge_point['var_values'],
                 edge_point['var_standard_names']
-            )])
+            ) if var_value])
         point.data = data
 
         try:

--- a/data-access/nexustiles/model/nexusmodel.py
+++ b/data-access/nexustiles/model/nexusmodel.py
@@ -47,7 +47,10 @@ class Tile(object):
     :attribute tile_stats: Dictionary representing the min, max, mean, and
         count of this tile
     :attribute var_names: A list of size N where N == the number of vars
-        this tile represents
+        this tile represents. This represents the variable name from the
+        source data file.
+    :attribute standard_names: A list of size N where N == the number of vars
+        this tile represents. This represents the CF 'standard_name' from the
     :attribute latitudes: 1-d ndarray representing the latitude values of
         this tile
     :attribute longitudes: 1-d ndarray representing the longitude values of
@@ -70,6 +73,7 @@ class Tile(object):
     max_time: str = None
     tile_stats: dict = None
     var_names: list = None
+    standard_names: list = None
     latitudes: np.array = None
     longitudes: np.array = None
     times: np.array = None

--- a/data-access/nexustiles/model/nexusmodel.py
+++ b/data-access/nexustiles/model/nexusmodel.py
@@ -27,75 +27,55 @@ TileStats = namedtuple('TileStats', 'min max mean count')
 @dataclass
 class Tile(object):
     """
-    :param tile_id: Unique UUID tile ID, also used in data store and
+    Tile class representing the contents of a tile. The tile contents
+    are populated using the metadata store and the data store.
+
+    :attribute tile_id: Unique UUID tile ID, also used in data store and
         metadata store to distinguish this tile
-    :type tile_id: Union[string, None]
-    :param dataset_id: Unique dataset ID this tile belongs to
-    :type dataset_id: string
-    :param section_spec: A summary of the indices used from the source
+    :attribute dataset_id: Unique dataset ID this tile belongs to
+    :attribute section_spec: A summary of the indices used from the source
         granule to create this tile. Format is
         dimension:min_index:max_index,dimension:min_index:max_index,...
-    :type section_spec: string
-    :param dataset: The name of the dataset this tile belongs to
-    :type dataset: string
-    :param granule: The name of the granule this tile is sourced from
-    :type granule: string
-    :param bbox: Comma-separated string representing the spatial bounds
+    :attribute dataset: The name of the dataset this tile belongs to
+    :attribute granule: The name of the granule this tile is sourced from
+    :attribute bbox: Comma-separated string representing the spatial bounds
         of this tile. The format is min_lon, min_lat, max_lon, max_lat
-    :type bbox: string
-    :param min_time: ISO 8601 formatted timestamp representing the
+    :attribute min_time: ISO 8601 formatted timestamp representing the
         temporal minimum of this tile
-    :type min_time: string
-    :param max_time: ISO 8601 formatted timestamp representing the
+    :attribute max_time: ISO 8601 formatted timestamp representing the
         temporal minimum of this tile
-    :type max_time: string
-    :param tile_stats: Dictionary representing the min, max, mean, and
+    :attribute tile_stats: Dictionary representing the min, max, mean, and
         count of this tile
-    :type tile_stats: dict
-    :param var_names: A list of size N where N == the number of vars
+    :attribute var_names: A list of size N where N == the number of vars
         this tile represents
-    :type var_names: list
-    :param latitudes: 1-d ndarray representing the latitude values of
+    :attribute latitudes: 1-d ndarray representing the latitude values of
         this tile
-    :type latitudes: ndarray
-    :param longitudes: 1-d ndarray representing the longitude values of
+    :attribute longitudes: 1-d ndarray representing the longitude values of
         this tile
-    :type longitudes: ndarray
-    :param times: 1-d ndarray representing the longitude values of
+    :attribute times: 1-d ndarray representing the longitude values of
         this tile
-    :type times: ndarray
-    :param data: This should be an ndarray with shape len(times) x
+    :attribute data: This should be an ndarray with shape len(times) x
         len(latitudes) x len(longitudes) x num_vars
-    :type data: ndarray
-    :param is_multi: 'True' if this is a multi-var tile
-    :type is_multi: boolean
-    :param meta_data: dict of the form { 'meta_data_name' :
-        [[[ndarray]]] }. Each ndarray should be the same shape as data.
-    :type meta_data: dict
+    :attribute is_multi: 'True' if this is a multi-var tile
+    :attribute meta_data: dict of the form {'meta_data_name':
+        [[[ndarray]]]}. Each ndarray should be the same shape as data.
     """
-    def __init__(self):
-        self.tile_id = None
-        self.dataset_id = None
-        self.section_spec = None
-        self.dataset = None
-        self.granule = None
-
-        self.bbox = None
-
-        self.min_time = None
-        self.max_time = None
-
-        self.tile_stats = None
-        self.var_names = None
-
-        self.latitudes = None
-        self.longitudes = None
-        self.times = None
-
-        self.data = None
-        self.is_multi = None
-
-        self.meta_data = None
+    tile_id: str = None
+    dataset_id: str = None
+    section_spec: str = None
+    dataset: str = None
+    granule: str = None
+    bbox: str = None
+    min_time: str = None
+    max_time: str = None
+    tile_stats: dict = None
+    var_names: list = None
+    latitudes: np.array = None
+    longitudes: np.array = None
+    times: np.array = None
+    data: np.array = None
+    is_multi: bool = None
+    meta_data: dict = None
 
     def __str__(self):
         return str(self.get_summary())

--- a/data-access/nexustiles/model/nexusmodel.py
+++ b/data-access/nexustiles/model/nexusmodel.py
@@ -25,6 +25,21 @@ TileStats = namedtuple('TileStats', 'min max mean count')
 
 
 @dataclass
+class TileVariable:
+    """
+    TileVariable class representing a single variable. This contains
+    both the name of the variable and the CF standard name.
+
+    :attribute variable_name: Name of the variable in the tile. This is
+    the name from the satellite data file.
+    :attribute standard_name: CF Standard name of the variable in the
+    tile. This is the 'standard_name' attribute from the satellite data file. This might be null in the case where the source variable does not contain a standard_name attribute.
+    """
+    variable_name: str = None
+    standard_name: str = None
+
+
+@dataclass
 class Tile(object):
     """
     Tile class representing the contents of a tile. The tile contents
@@ -46,11 +61,8 @@ class Tile(object):
         temporal minimum of this tile
     :attribute tile_stats: Dictionary representing the min, max, mean, and
         count of this tile
-    :attribute var_names: A list of size N where N == the number of vars
-        this tile represents. This represents the variable name from the
-        source data file.
-    :attribute standard_names: A list of size N where N == the number of vars
-        this tile represents. This represents the CF 'standard_name' from the
+    :attribute variables: A list of size N where N == the number of vars
+        this tile represents. The list type is TileVariable.
     :attribute latitudes: 1-d ndarray representing the latitude values of
         this tile
     :attribute longitudes: 1-d ndarray representing the longitude values of
@@ -72,8 +84,7 @@ class Tile(object):
     min_time: str = None
     max_time: str = None
     tile_stats: dict = None
-    var_names: list = None
-    standard_names: list = None
+    variables: list = None
     latitudes: np.array = None
     longitudes: np.array = None
     times: np.array = None

--- a/data-access/nexustiles/model/nexusmodel.py
+++ b/data-access/nexustiles/model/nexusmodel.py
@@ -137,7 +137,12 @@ class Tile(object):
         if include_nan:
             return list(np.ndindex(self.data.shape))
         if self.is_multi:
-            return np.argwhere(self.data[0])
+            # For each variable, combine masks. This is a logical or
+            # operation, because we want to ensure we don't lose any
+            # data.
+            combined_data_mask = np.logical_or(*self.data)
+            # Return the indices where the data is valid
+            return np.argwhere(combined_data_mask)
         else:
             return np.transpose(np.where(np.ma.getmaskarray(self.data) == False)).tolist()
 

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -529,10 +529,34 @@ class NexusTileService(object):
             except KeyError:
                 pass
 
-            tile.variables = []
+            try:
+                # Ensure backwards compatibility by working with old
+                # tile_var_name_s and tile_standard_name_s fields to
+
+                # will be overwritten if tile_var_name_ss is present
+                # as well.
+                if '[' in solr_doc['tile_var_name_s']:
+                    var_names = json.loads(solr_doc['tile_var_name_s'])
+                else:
+                    var_names = [solr_doc['tile_var_name_s']]
+
+                if '[' in solr_doc['tile_standard_name_s']:
+                    standard_names = json.loads(solr_doc['tile_standard_name_s'])
+                else:
+                    standard_names = [solr_doc['tile_standard_name_s']]
+
+                tile.variables = []
+                for var_name, standard_name in zip(var_names, standard_names):
+                    tile.variables.append(TileVariable(
+                        variable_name=var_name,
+                        standard_name=standard_name
+                    ))
+            except KeyError:
+                pass
 
 
             if 'tile_var_name_ss' in solr_doc:
+                tile.variables = []
                 for var_name in solr_doc['tile_var_name_ss']:
                     standard_name_key = f'{var_name}.tile_standard_name_s'
                     standard_name = solr_doc.get(standard_name_key)

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -540,6 +540,16 @@ class NexusTileService(object):
             except KeyError:
                 pass
 
+            try:
+                # tile_standard_name_s is a json encoded list of strings
+                # (or just a single string).
+                if '[' in solr_doc['tile_standard_name_s']:
+                    tile.standard_names = json.loads(solr_doc['tile_standard_name_s'])
+                else:
+                    tile.standard_names = [solr_doc['tile_standard_name_s']]
+            except KeyError:
+                pass
+
             tiles.append(tile)
 
         return tiles

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -540,10 +540,14 @@ class NexusTileService(object):
                 else:
                     var_names = [solr_doc['tile_var_name_s']]
 
-                if '[' in solr_doc['tile_standard_name_s']:
-                    standard_names = json.loads(solr_doc['tile_standard_name_s'])
+                standard_name = solr_doc.get(
+                        'tile_standard_name_s',
+                        json.dumps([None] * len(var_names))
+                )
+                if '[' in standard_name:
+                    standard_names = json.loads(standard_name)
                 else:
-                    standard_names = [solr_doc['tile_standard_name_s']]
+                    standard_names = [standard_name]
 
                 tile.variables = []
                 for var_name, standard_name in zip(var_names, standard_names):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SDAP-338

Added support for multi-var tiles in the matchup algorithm. This support exists for multi-variable swath and gridded tiles. 

I went back and forth a lot about the best way to do this. In the end, I decided the best way for now is to make it backwards compatible so the other algorithms can be updated as-needed. This means all algorithms should work as normal on single-var tiles, but would need to update their code to work with multi-var. 

An alternative idea would be to update our tile representation drastically, which would require all algorithms to be updated for both single and multi var tiles. This might be the 'right' way to do this at some point, but for now the approach I went with is the one with the smallest impact on other SDAP algorithms.

In order to support this I made the following changes:

- Modified `Tile`:
  - Added a new variable `is_multi` which is True when the tile is multi-var.
  - Changed the name of `var_name` to `var_names`. In the single-var case, this will be a list of size 1.
- In `CassandraProxy`, added a new case in `get_lat_lon_time_data_meta` for `swath_multi_variable_tile` and `grid_multi_variable_tile`.
  - In both cases, the 'num vars' dimension is moved to the front of the nd array. This is counter to the shape provided by the ingester. The ingester has the 'num vars' dimension at the end of the nd array. For example, let's say the data is size 30 x 30 x 30, and there are two variables. That means the ingester will store the tile data as 30 x 30 x 30 x 2, whereas in `get_lat_lon_time_data_meta` I'm transforming that to 2 x 30 x 30 x 30. The reason for this is because the algorithm doesn't really have to change, you can run the same algorithm on `data[0], data[1], ...` and it should just work. I'm definitely looking for feedback on this decision, because I can see the argument both ways.
  - In the single var case, the data size would be 30 x 30 x 30 (using the example from above) without the extra dimension. The is_multi flag needs to be used by algorithms to determine which shape to expect the data.
- Updated `nexustiles._solr_docs_to_tiles` to parse var_names from `var_name` field, where that field is a JSON encoded array (according to William)
- Updated `Tile` to utilize dataclasses. This just cleaned up the code and allowed removal of boilerplate code.
- Updated code in various places to work with the case where Tile.is_multi == True.
- Added docstrings as I was going where missing and where clarification was probably needed due to changes.
- Added more unit tests to test_matchup.py. Updated existing unit tests to work with changes.

The matchup algorithm was tested with:

1. Single-var sat to in-situ
2. Single-var sat to single-var sat
3. Multi-var sat to single-var sat
4. Multi-var sat to multi-var sat
5. Multi-var sat to in-situ

NOTE: I'm still working on adding additional unit tests for `nexustiles` but thought I'd open the PR ASAP because it's large. 