### PR TITLE
SDAP-353: Update matchup output to only return variables that are relevant to the given dataset

### DIFF
--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -305,14 +305,6 @@ class Matchup(NexusCalcSparkHandler):
     @staticmethod
     def domspoint_to_dict(domspoint):
         doms_dict = {
-            "sea_water_temperature": domspoint.sst,
-            "sea_water_temperature_depth": domspoint.sst_depth,
-            "sea_water_salinity": domspoint.sss,
-            "sea_water_salinity_depth": domspoint.sss_depth,
-            "wind_speed": domspoint.wind_speed,
-            "wind_direction": domspoint.wind_direction,
-            "wind_u": domspoint.wind_u,
-            "wind_v": domspoint.wind_v,
             "platform": doms_values.getPlatformById(domspoint.platform),
             "device": doms_values.getDeviceById(domspoint.device),
             "x": str(domspoint.longitude),
@@ -356,14 +348,6 @@ class DomsPoint(object):
 
         self.data = None
 
-        self.wind_u = None
-        self.wind_v = None
-        self.wind_direction = None
-        self.wind_speed = None
-        self.sst = None
-        self.sst_depth = None
-        self.sss = None
-        self.sss_depth = None
         self.source = None
         self.depth = None
         self.platform = None
@@ -444,14 +428,6 @@ class DomsPoint(object):
 
         point.time = edge_point['time']
 
-        point.wind_u = edge_point.get('eastward_wind')
-        point.wind_v = edge_point.get('northward_wind')
-        point.wind_direction = edge_point.get('wind_direction')
-        point.wind_speed = edge_point.get('wind_speed')
-        point.sst = edge_point.get('sea_water_temperature')
-        point.sst_depth = edge_point.get('sea_water_temperature_depth')
-        point.sss = edge_point.get('sea_water_salinity')
-        point.sss_depth = edge_point.get('sea_water_salinity_depth')
         point.source = edge_point.get('source')
         point.platform = edge_point.get('platform')
         point.device = edge_point.get('device')


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SDAP-353

Updated the matchup output to only output relevant variables, instead of always including `sea_water_temperature`, `wind_direction`, etc in the result even when null.

This is a trivial change due to the previous schema changes where the result data/variable name/cf variable name were added.

## Testing:

### Satellite to satellite:

```
{{big_data_url}}/match_spark?primary=avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020&startTime=2018-10-30T00:00:00Z&endTime=2018-11-05T00:00:00Z&tt=2592000&rt=1000&b=-180,-90,-160,-70&platforms=1,2,3,4,5,6,7,8,9&parameter=sst&depthMin=0&depthMax=5&matchOnce=true&matchup=MUR25-JPL-L4-GLOB-v04.2&resultSizeLimit=6000
```

(results truncated)
```json
{
    "executionId": "53d5a027-4f5c-4395-9874-9d549a92641a",
    "data": [
        {
            "platform": "orbiting satellite",
            "device": "radiometers",
            "x": "-164.875",
            "y": "-74.625",
            "point": "Point(-164.875 -74.625)",
            "time": 1540857600,
            "fileurl": "20181030120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.0.nc",
            "id": "1be456ef-dffd-3efb-a967-491b9960661b[[0, 1, 0]]",
            "source": "avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020",
            "data": [
                {
                    "variable_name": "sea_surface_temperature",
                    "cf_variable_name": null,
                    "variable_value": 271.3699951171875
                }
            ],
            "matches": [
                {
                    "platform": null,
                    "device": null,
                    "x": "-164.875",
                    "y": "-74.625",
                    "point": "Point(-164.875 -74.625)",
                    "time": 1543395600,
                    "fileurl": "20181128090000-JPL-L4_GHRSST-SSTfnd-MUR25-GLOB-v02.0-fv04.2.nc",
                    "id": "2018-11-28T09:00:00Z:-164.875:-74.625",
                    "source": "MUR25-JPL-L4-GLOB-v04.2",
                    "data": [
                        {
                            "variable_name": "analysed_sst",
                            "cf_variable_name": "sea_surface_foundation_temperature",
                            "variable_value": -1.79998779296875
                        },
                        {
                            "variable_name": "analysis_error",
                            "cf_variable_name": null,
                            "variable_value": -272.7900085449219
                        },
                        {
                            "variable_name": "sst_anomaly",
                            "cf_variable_name": null,
                            "variable_value": 1.0
                        }
                    ]
                }
            ]
        }
    ],
    "params": {
        "primary": "avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020",
        "matchup": "MUR25-JPL-L4-GLOB-v04.2",
        "startTime": 1540857600,
        "endTime": 1541376000,
        "bbox": "-180,-90,-160,-70",
        "timeTolerance": 2592000,
        "radiusTolerance": 1000.0,
        "platforms": "1,2,3,4,5,6,7,8,9",
        "parameter": "sst",
        "depthMin": 0.0,
        "depthMax": 5.0
    },
    "bounds": {},
    "count": null,
    "details": {
        "timeToComplete": 75,
        "numInSituRecords": 0,
        "numInSituMatched": 5440,
        "numGriddedChecked": 0,
        "numGriddedMatched": 5440
    }
}
```

### Satellite to in-situ

```
{{big_data_url}}/match_spark?primary=ascat-l2-coastal-test4&startTime=2017-01-02T18:59:37Z&endTime=2017-01-02T19:00:31Z&tt=86400&rt=100000&b=-126,44,-119,49&platforms=1,2,3,4,5,6,7,8,9&depthMin=0&depthMax=5&matchOnce=true&matchup=icoads
```

```json
{
    "executionId": "374c0b42-0851-4a0b-a4e7-25f776d7f5bc",
    "data": [
        {
            "platform": "orbiting satellite",
            "device": "radiometers",
            "x": "-125.82383999999999",
            "y": "48.816370000000006",
            "point": "Point(-125.82383999999999 48.816370000000006)",
            "time": 1483383588,
            "fileurl": "ascat_20170102_182400_metopb_22278_eps_o_coa_2401_ovw.l2.nc",
            "id": "6174319e-464c-306a-a44b-5c55431253a6[[95 95 95]]",
            "source": "ascat-l2-coastal-test4",
            "data": [
                {
                    "variable_name": "wind_speed",
                    "cf_variable_name": "wind_speed",
                    "variable_value": 9.639999389648438
                },
                {
                    "variable_name": "wind_dir",
                    "cf_variable_name": "wind_to_direction",
                    "variable_value": 226.60000610351562
                }
            ],
            "matches": [
                {
                    "platform": "moored surface buoy",
                    "device": null,
                    "x": "-126.0",
                    "y": "48.8",
                    "point": "Point(-126.0 48.8)",
                    "time": 1483362000,
                    "fileurl": null,
                    "id": "N2H8TB",
                    "source": "icoads",
                    "data": [
                        {
                            "variable_name": "eastward_wind",
                            "cf_variable_name": null,
                            "variable_value": -6.9
                        },
                        {
                            "variable_name": "northward_wind",
                            "cf_variable_name": null,
                            "variable_value": -5.8
                        },
                        {
                            "variable_name": "wind_speed",
                            "cf_variable_name": null,
                            "variable_value": 9.0
                        },
                        {
                            "variable_name": "sea_water_temperature",
                            "cf_variable_name": null,
                            "variable_value": 10.9
                        }
                    ]
                }
            ]
        }
    ],
    "params": {
        "primary": "ascat-l2-coastal-test4",
        "matchup": "icoads",
        "startTime": 1483383577,
        "endTime": 1483383631,
        "bbox": "-126,44,-119,49",
        "timeTolerance": 86400,
        "radiusTolerance": 100000.0,
        "platforms": "1,2,3,4,5,6,7,8,9",
        "parameter": null,
        "depthMin": 0.0,
        "depthMax": 5.0
    },
    "bounds": {},
    "count": null,
    "details": {
        "timeToComplete": 44,
        "numInSituRecords": 0,
        "numInSituMatched": 251,
        "numGriddedChecked": 0,
        "numGriddedMatched": 251
    }
}
```

For reference, the result looked like this before: https://github.com/apache/incubator-sdap-nexus/pull/131