### PR TITLE
Updated deletebyquery.py tool

### DIFF
--- a/tools/deletebyquery/deletebyquery.py
+++ b/tools/deletebyquery/deletebyquery.py
@@ -192,6 +192,7 @@ def delete_from_cassandra(doc_ids):
 
 
 def delete_from_solr(query):
+    global solr_collection
     if not solr_delete_from_all_collections:
         solr_collection.delete(query, commit=False)
         solr_collection.commit()


### PR DESCRIPTION
**Included in this PR:**
- [x] Specified `cassandraPort` option to return an integer. Cassandra port number needs to be an integer. Otherwise, Cassandra library will throw an error.
- [x] Added option to delete from all SOLR collections (i.e. `nexusgranules`, `nexusdatasets`). The current implementation limits to only `nexustiles`.