### PR TITLE
SDAP-355: Update matchup parameter and output to use primary and secondary

### DIFF
--- a/analysis/tests/algorithms_spark/test_matchup.py
+++ b/analysis/tests/algorithms_spark/test_matchup.py
@@ -63,7 +63,7 @@ def test_matchup_args():
     tile_ids = [1]
     polygon_wkt = 'POLYGON((-34.98 29.54, -30.1 29.54, -30.1 31.00, -34.98 31.00, -34.98 29.54))'
     primary_ds_name = 'primary-ds-name'
-    matchup_ds_names = 'test'
+    secondary_ds_names = 'test'
     parameter = 'sst'
     depth_min = 0.0
     depth_max = 1.0
@@ -74,7 +74,7 @@ def test_matchup_args():
     yield dict(
         tile_ids=tile_ids,
         primary_b=MockSparkParam(primary_ds_name),
-        matchup_b=MockSparkParam(matchup_ds_names),
+        secondary_b=MockSparkParam(secondary_ds_names),
         parameter_b=MockSparkParam(parameter),
         tt_b=MockSparkParam(time_tolerance),
         rt_b=MockSparkParam(radius_tolerance),
@@ -238,12 +238,12 @@ def test_calc(test_matchup_args):
                 assert matches['x'] == '-180'
                 assert matches['y'] == '-90'
 
-        assert json_matchup_result['data'][0]['data'][0]['variable_value'] == 10.0
-        assert json_matchup_result['data'][1]['data'][0]['variable_value'] == 20.0
-        assert json_matchup_result['data'][0]['matches'][0]['data'][0]['variable_value'] == 30.0
-        assert json_matchup_result['data'][0]['matches'][1]['data'][0]['variable_value'] == 40.0
-        assert json_matchup_result['data'][1]['matches'][0]['data'][0]['variable_value'] == 30.0
-        assert json_matchup_result['data'][1]['matches'][1]['data'][0]['variable_value'] == 40.0
+        assert json_matchup_result['data'][0]['primary'][0]['variable_value'] == 10.0
+        assert json_matchup_result['data'][1]['primary'][0]['variable_value'] == 20.0
+        assert json_matchup_result['data'][0]['matches'][0]['secondary'][0]['variable_value'] == 30.0
+        assert json_matchup_result['data'][0]['matches'][1]['secondary'][0]['variable_value'] == 40.0
+        assert json_matchup_result['data'][1]['matches'][0]['secondary'][0]['variable_value'] == 30.0
+        assert json_matchup_result['data'][1]['matches'][1]['secondary'][0]['variable_value'] == 40.0
 
         assert json_matchup_result['details']['numInSituMatched'] == 4
         assert json_matchup_result['details']['numGriddedMatched'] == 2
@@ -315,7 +315,7 @@ def test_match_satellite_to_insitu(test_dir, test_tile, test_matchup_args):
         match_args = dict(
             tile_ids=tile_ids,
             primary_b=MockSparkParam(primary_ds_name),
-            matchup_b=MockSparkParam(matchup_ds_names),
+            secondary_b=MockSparkParam(matchup_ds_names),
             parameter_b=MockSparkParam(parameter),
             tt_b=MockSparkParam(time_tolerance),
             rt_b=MockSparkParam(radius_tolerance),

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -31,7 +31,7 @@ paths:
             type: string
           example: avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020
         - in: query
-          name: matchup
+          name: secondary
           description: |
             The dataset(s) being searched for measurements that match
             the measurements in primary. One or more (comma-separated)
@@ -632,26 +632,28 @@ components:
             data:
               type: array
               items:
-                $ref: '#/components/schemas/DomsPoint'
-    DomsPoint:
+                $ref: '#/components/schemas/DomsPointPrimary'
+    DomsPointPrimary:
+      allOf:
+        - $ref: '#/components/schemas/DomsPointBase'
+        - type: object
+          properties:
+            primary:
+              type: array
+              items:
+                $ref: '#/components/schemas/DomsDataPoint'
+    DomsPointSecondary:
+      allOf:
+        - $ref: '#/components/schemas/DomsPointBase'
+        - type: object
+          properties:
+            secondary:
+              type: array
+              items:
+                $ref: '#/components/schemas/DomsDataPoint'
+    DomsPointBase:
       type: object
       properties:
-        sea_water_temperature:
-          type: number
-        sea_water_temperature_depth:
-          type: number
-        sea_water_salinity:
-          type: number
-        sea_water_salinity_depth:
-          type: number
-        wind_speed:
-          type: number
-        wind_direction:
-          type: number
-        wind_u:
-          type: number
-        wind_v:
-          type: number
         platform:
           type: string
         device:
@@ -671,12 +673,19 @@ components:
           type: string
         source:
           type: string
-        analysed_sst:
-          type: number # TODO Fix this
         matches:
           type: array
           items:
-            $ref: '#/components/schemas/DomsPoint'
+            $ref: '#/components/schemas/DomsPointSecondary'
+    DomsDataPoint:
+      type: object
+      properties:
+        variable_name:
+          type: string
+        cf_variable_name:
+          type: string
+        variable_value:
+          type: number
     DomsList:
       allOf:
         - $ref: '#/components/schemas/DomsQueryResult'

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -638,6 +638,12 @@ components:
         - $ref: '#/components/schemas/DomsPointBase'
         - type: object
           properties:
+            matches:
+              type: array
+              items:
+                $ref: '#/components/schemas/DomsPointSecondary'
+        - type: object
+          properties:
             primary:
               type: array
               items:
@@ -673,10 +679,6 @@ components:
           type: string
         source:
           type: string
-        matches:
-          type: array
-          items:
-            $ref: '#/components/schemas/DomsPointSecondary'
     DomsDataPoint:
       type: object
       properties:


### PR DESCRIPTION
- Updated matchup request param from `matchup` to `secondary`
- Updated matchup output `data` to either `primary` or `secondary`
- Updated `matchup` terminology to `secondary` in code for consistency.
- Updated unit tests to work with these changes.
- Updated OpenAPI spec to reflect changes.

Tested locally:

```
{{big_data_url}}/match_spark?primary=ASCATB-L2-Coastal&startTime=2017-02-28T12:03:16Z&endTime=2017-02-28T12:03:16Z&tt=86400&rt=100000&b=100,0,150,20&platforms=1,2,3,4,5,6,7,8,9&depthMin=0&depthMax=5&matchOnce=true&secondary=icoads
```

(results truncated)


```json
{
    "executionId": "e9803ae1-bbe2-4fad-814e-ce42752183b3",
    "data": [
        {
            "platform": "orbiting satellite",
            "device": "radiometers",
            "x": "133.93401",
            "y": "15.697170000000002",
            "point": "Point(133.93401 15.697170000000002)",
            "time": 1488283411,
            "fileurl": "ascat_20170228_120000_metopb_23084_eps_o_coa_2401_ovw.l2.nc",
            "id": "6e9cd393-8375-3b35-8b2b-d7cd55740267[[127 127 127]]",
            "source": "ASCATB-L2-Coastal",
            "primary": [
                {
                    "variable_name": "wind_speed",
                    "cf_variable_name": "wind_speed",
                    "variable_value": 8.569999694824219
                },
                {
                    "variable_name": "wind_dir",
                    "cf_variable_name": "wind_to_direction",
                    "variable_value": 232.1999969482422
                }
            ],
            "matches": [
                {
                    "platform": "drifting surface float",
                    "device": null,
                    "x": "134.0",
                    "y": "16.37",
                    "point": "Point(134.0 16.37)",
                    "time": 1488368700,
                    "fileurl": null,
                    "id": "N9TAJF",
                    "source": "icoads",
                    "secondary": [
                        {
                            "variable_name": "sea_water_temperature",
                            "cf_variable_name": null,
                            "variable_value": 26.7
                        }
                    ]
                }
            ]
        }
    ],
    "params": {
        "primary": "ASCATB-L2-Coastal",
        "matchup": "icoads",
        "startTime": 1488283396,
        "endTime": 1488283396,
        "bbox": "100,0,150,20",
        "timeTolerance": 86400,
        "radiusTolerance": 100000.0,
        "platforms": "1,2,3,4,5,6,7,8,9",
        "parameter": null,
        "depthMin": 0.0,
        "depthMax": 5.0
    },
    "bounds": {},
    "count": null,
    "details": {
        "timeToComplete": 22,
        "numInSituRecords": 0,
        "numInSituMatched": 434,
        "numGriddedChecked": 0,
        "numGriddedMatched": 434
    }
}
```


```
{{big_data_url}}/match_spark?primary=avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020&startTime=2018-10-30T00:00:00Z&endTime=2018-11-05T00:00:00Z&tt=2592000&rt=1000&b=-180,-90,-160,-70&platforms=1,2,3,4,5,6,7,8,9&parameter=sst&depthMin=0&depthMax=5&matchOnce=true&secondary=MUR25-JPL-L4-GLOB-v04.2&resultSizeLimit=6000
```

(results truncated)

```json
{
    "executionId": "78866cfc-72db-4897-be4f-3437e87b9900",
    "data": [
        {
            "platform": "orbiting satellite",
            "device": "radiometers",
            "x": "-164.375",
            "y": "-74.875",
            "point": "Point(-164.375 -74.875)",
            "time": 1540857600,
            "fileurl": "20181030120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.0.nc",
            "id": "1be456ef-dffd-3efb-a967-491b9960661b[[0, 0, 2]]",
            "source": "avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020",
            "primary": [
                {
                    "variable_name": "sea_surface_temperature",
                    "cf_variable_name": null,
                    "variable_value": 271.3699951171875
                }
            ],
            "matches": [
                {
                    "platform": null,
                    "device": null,
                    "x": "-164.375",
                    "y": "-74.875",
                    "point": "Point(-164.375 -74.875)",
                    "time": 1543395600,
                    "fileurl": "20181128090000-JPL-L4_GHRSST-SSTfnd-MUR25-GLOB-v02.0-fv04.2.nc",
                    "id": "2018-11-28T09:00:00Z:-164.375:-74.875",
                    "source": "MUR25-JPL-L4-GLOB-v04.2",
                    "secondary": [
                        {
                            "variable_name": "analysed_sst",
                            "cf_variable_name": "sea_surface_foundation_temperature",
                            "variable_value": -1.79998779296875
                        },
                        {
                            "variable_name": "analysis_error",
                            "cf_variable_name": null,
                            "variable_value": -272.7900085449219
                        },
                        {
                            "variable_name": "sst_anomaly",
                            "cf_variable_name": null,
                            "variable_value": 1.0
                        }
                    ]
                }
            ]
        }
    ],
    "params": {
        "primary": "avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020",
        "matchup": "MUR25-JPL-L4-GLOB-v04.2",
        "startTime": 1540857600,
        "endTime": 1541376000,
        "bbox": "-180,-90,-160,-70",
        "timeTolerance": 2592000,
        "radiusTolerance": 1000.0,
        "platforms": "1,2,3,4,5,6,7,8,9",
        "parameter": "sst",
        "depthMin": 0.0,
        "depthMax": 5.0
    },
    "bounds": {},
    "count": null,
    "details": {
        "timeToComplete": 92,
        "numInSituRecords": 0,
        "numInSituMatched": 5440,
        "numGriddedChecked": 0,
        "numGriddedMatched": 5440
    }
}
```