### PR TITLE
change solr helm chart dependency to stable

### DIFF
--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -12,11 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM solr:8.4.0
-
+FROM bitnami/solr:8.11.0-debian-10-r0
+ADD https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.15.0/jts-core-1.15.0.jar /opt/bitnami/solr/server/solr-webapp/webapp/WEB-INF/lib/jts-core-1.15.0.jar
 USER root
-
-RUN wget https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.17.1/jts-core-1.17.1.jar && \
-    cp jts-core-1.17.1.jar /opt/solr/server/solr-webapp/webapp/WEB-INF/lib/jts-core-1.17.1.jar
-ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["solr-foreground"]
+RUN chmod a+r /opt/bitnami/solr/server/solr-webapp/webapp/WEB-INF/lib/jts-core-1.15.0.jar
+USER 1001

--- a/docker/solr/Readme.rst
+++ b/docker/solr/Readme.rst
@@ -34,7 +34,7 @@ This image can be built by:
 
 .. code-block:: bash
 
-    docker build -t sdap/solr:${BUILD_VERSION} .
+    docker build -t nexusjpl/solr:${BUILD_VERSION} .
 
 How to Run
 ^^^^^^^^^^

--- a/helm/requirements.yaml
+++ b/helm/requirements.yaml
@@ -8,8 +8,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled
   - name: solr
-    version: 1.5.2
-    repository: https://charts.helm.sh/incubator
+    version: 2.1.3
+    repository: https://charts.bitnami.com/bitnami
     condition: solr.enabled
   - name: cassandra
     version: 5.5.3

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -48,7 +48,7 @@ The data volume mount which is used in both the Collection Manager and the Granu
 {{- end -}}
 
 {{- define "nexus.urls.solr" -}}
-{{ .Values.external.solrHostAndPort | default (print "http://" .Release.Name "-solr-svc:8983") }}
+{{ .Values.external.solrHostAndPort | default (print "http://" .Release.Name "-solr:8983") }}
 {{- end -}}
 
 {{- define "nexus.urls.zookeeper" -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -122,6 +122,8 @@ solr:
     repository: nexusjpl/solr
     tag: 8.4.0
   replicaCount: 3
+  authentication:
+    enabled: false
   volumeClaimTemplates:
     storageClassName: hostpath
     storageSize: 10Gi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -120,7 +120,7 @@ solr:
   initPodEnabled: true
   image:
     repository: nexusjpl/solr
-    tag: 8.4.0
+    tag: 8.11.0
   replicaCount: 3
   authentication:
     enabled: false


### PR DESCRIPTION
The helm chart is updated to use the bitnami stable chart instead of the incubator version previously.

The update requires the use of a specific docker solr image to have the JTS jar for geospatial support. The dockerfile is published there https://github.com/tloubrieu-jpl/solr-with-jts-docker.
The docker image still need to be published outside of tloubrieu dockerhub organization.

The update also requires an update of the granule ingester component for its connection to solr, see pull request https://github.com/apache/incubator-sdap-ingester/pull/50



