### PR TITLE
SDAP-364: Upgrade Solr to 8.11.1

### DIFF
--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM bitnami/solr:8.11.0-debian-10-r0
+FROM bitnami/solr:8.11.1-debian-10-r0
 ADD https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.15.0/jts-core-1.15.0.jar /opt/bitnami/solr/server/solr-webapp/webapp/WEB-INF/lib/jts-core-1.15.0.jar
 USER root
 RUN chmod a+r /opt/bitnami/solr/server/solr-webapp/webapp/WEB-INF/lib/jts-core-1.15.0.jar

--- a/helm/requirements.yaml
+++ b/helm/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled
   - name: solr
-    version: 2.1.3
+    version: 2.1.7
     repository: https://charts.bitnami.com/bitnami
     condition: solr.enabled
   - name: cassandra

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -120,7 +120,7 @@ solr:
   initPodEnabled: true
   image:
     repository: nexusjpl/solr
-    tag: 8.11.0
+    tag: 8.11.1
   replicaCount: 3
   authentication:
     enabled: false


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SDAP-364

Bump Solr version to address log4j vulnerability. Pushed bumped solr image to dockerhub: `nexusjpl/solr:8.11.1`

Note: This has not yet been tested. The cdms and bigdata deployments are not using the solr bitnami chart yet (that's new) so I'm still investigating the best way to do this.