### PR TITLE
SDAP-318 Updated timeSeriesSpark algorithm to find tiles by bounding box instead of polygon

### DIFF
--- a/analysis/tests/algorithms_spark/test_timeseriesspark.py
+++ b/analysis/tests/algorithms_spark/test_timeseriesspark.py
@@ -136,7 +136,7 @@ def test_calc_average_on_day():
         tile_service.get_bounding_box.return_value = box(-90, -45, 90, 45)
         tile_service.get_min_time.return_value = 1627490285
         tile_service.get_max_time.return_value = 1627490285
-        tile_service.get_tiles_bounded_by_polygon.return_value = [test_tile]
+        tile_service.get_tiles_bounded_by_box.return_value = [test_tile]
         tile_service.mask_tiles_to_polygon.return_value = [test_tile]
         return tile_service_factory
 
@@ -147,7 +147,7 @@ def test_calc_average_on_day():
         pass
 
     # Spark tile format: (polygon string, ds name, list of time stamps, fill value)
-    spark_tile = ('POLYGON((-34.98 29.54, -30.1 29.54, -30.1 31.00, -34.98 31.00, -34.98 29.54))', 
+    spark_tile = (wkt.loads('POLYGON((-34.98 29.54, -30.1 29.54, -30.1 31.00, -34.98 31.00, -34.98 29.54))'), 
                     'dataset', timestamps, -9999.)
 
     avg_args = dict(


### PR DESCRIPTION
Apache ticket: [SDAP-318](https://issues.apache.org/jira/browse/SDAP-318)

This updates the timeSeriesSpark algorithm to use the bounding box (instead of polygon) to perform spatial searching on Solr. This is in line with how the other algorithms do spatial searching. 

**The issue**: Polygon search runs into an inherent issue with WKT strings where bounding boxes with > 180 difference between maxLon and minLon. This results in no tiles being returned from Solr, and an empty list being returned for the algorithm results. 

**The fix**: Update algorithm to use [get_tiles_bounded_by_box](https://github.com/apache/incubator-sdap-nexus/blob/6583534206a1d9dbfb1eb1bada50af6f3e09396a/data-access/nexustiles/nexustiles.py#L260) instead of [get_tiles_bounded_by_polygon](https://github.com/apache/incubator-sdap-nexus/blob/6583534206a1d9dbfb1eb1bada50af6f3e09396a/data-access/nexustiles/nexustiles.py#L269). In `spark_driver` the list of nexus tiles has been updated to use the polygon itself instead of the polygon's WKT string representation. This allows for the use of the polygon's bounds for `get_tiles_bounded_by_box`, and is consistent with how other algorithms pass bounds.

The algorithm's test has also been updated to reflect this change:
```
(nexus) marlis@RAYL-C01360 incubator-sdap-nexus % pytest analysis/tests/algorithms_spark/test_timeseriesspark.py
========================================== test session starts ==========================================
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/marlis/Developer/ECCO/SDAP/incubator-sdap-nexus/analysis
collected 5 items                                                                                       

analysis/tests/algorithms_spark/test_timeseriesspark.py .....                                     [100%]

===================================== 5 passed, 9 warnings in 6.42s =====================================
```