### PR TITLE
Fix matchup bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-372: Added new matchup endpoint `match_spark_doms` that points to DOMS insitu endpoint
 - SDAP-372: Updated `match_spark_doms` to interface with samos_cdms endpoint 
 ### Changed
+- domslist endpoint points to AWS insitu instead of doms insitu
 ### Deprecated
 ### Removed
+- removed dropdown from matchup doms endpoint secondary param
 ### Fixed
 - Fix failing test_matchup unit test
+- Fixed bug in OpenAPI spec where both matchup endpoints shared the same id
 ### Security

--- a/analysis/webservice/algorithms/doms/DatasetListQuery.py
+++ b/analysis/webservice/algorithms/doms/DatasetListQuery.py
@@ -98,15 +98,22 @@ class DomsDatasetListQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
         for satellite in satellitesList:
             satellite["metadata"] = self.getMetadataForSource(satellite["shortName"])
 
-        for insitu in config.ENDPOINTS:
-            depths, facets = self.getFacetsForInsituSource(insitu)
-            insituList.append({
-                "name": insitu["name"],
-                "endpoint": insitu["url"],
-                "metadata": self.getMetadataForSource(insitu["name"]),
-                "depths": depths,
-                "facets": facets
-            })
+        for insitu in config.INSITU_PROVIDER_MAP:
+            provider = insitu['name']
+            for project in insitu['projects']:
+                project_name = project['name']
+                insituList.append({
+                    'name': project_name,
+                    'endpoint': f'{config.INSITU_API_ENDPOINT}?provider={provider}&project={project_name}',
+                    'metadata': {
+                        'Projects': [
+                            {
+                                'ShortName': project_name,
+                                'LongName': project_name
+                            }
+                        ]
+                    }
+                })
 
         values = {
             "satellite": satellitesList,

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -854,13 +854,14 @@ def query_edge(dataset, variable, startTime, endTime, bbox, platform, depth_min,
     # Get all edge results
     next_page_url = edge_endpoints.getEndpoint()
     while next_page_url is not None and next_page_url != 'NA':
-        logging.debug(f'Edge request {next_page_url}')
+        the_time = datetime.now()
         if session is not None:
             edge_page_request = session.get(next_page_url, params=params)
         else:
             edge_page_request = requests.get(next_page_url, params=params)
 
         edge_page_request.raise_for_status()
+        logging.info("%s Time to query edge %s", datetime.now() - the_time, edge_page_request.url)
 
         edge_page_response = json.loads(edge_page_request.text)
 

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -14,170 +14,11 @@ tags:
   - name: Subsetting
     description: Data Subsetting API
 paths:
-  /match_spark_doms:
-    get:
-      summary: Execute matchup request
-      operationId: matchup
-      tags:
-        - Matchup
-      parameters:
-        - in: query
-          name: primary
-          description: |
-            The primary dataset used to find matches for. One of the
-            satellite "shortName" as supplied by /domslist endpoint.
-          required: true
-          schema:
-            type: string
-            x-dspopulate:
-             - satellite
-          example: avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020
-        - in: query
-          name: secondary
-          description: |
-            The dataset(s) being searched for measurements that match
-            the measurements in primary. One or more (comma-separated)
-            of the insitu or satellite "name" as supplied by
-            https://doms.jpl.nasa.gov/domslist
-          required: true
-          schema:
-            type: string
-            x-dspopulate:
-             - satellite
-             - insitu
-          example: icoads
-        - in: query
-          name: startTime
-          description: |
-            Starting time in format YYYY-MM-DDTHH:mm:ssZ or seconds
-            since epoch
-          required: true
-          schema:
-            type: string
-            format: date-time
-          example: '2012-09-25T00:00:00Z'
-        - in: query
-          name: endTime
-          description: |
-            Ending time in format YYYY-MM-DDTHH:mm:ssZ or seconds
-            since epoch
-          required: true
-          schema:
-            type: string
-            format: date-time
-          example: '2012-09-30T23:59:59Z'
-        - in: query
-          name: b
-          description: |
-            Minimum (Western) Longitude, Minimum (Southern) Latitude,
-            Maximum (Eastern) Longitude, Maximum (Northern) Latitude
-          required: true
-          schema:
-            type: string
-          example: -45,15,-30,30
-        - in: query
-          name: platforms
-          description: Platforms to include for matchup consideration
-          required: true
-          schema:
-            type: string
-          example: 1,2,3,4,5,6,7,8,9
-        - in: query
-          name: depthMin
-          description: |
-            Minimum depth of measurements allowed to be considered for
-            matchup
-          required: false
-          schema:
-            type: integer
-          example: 0
-        - in: query
-          name: depthMax
-          description: |
-            Maximum depth of measurements allowed to be considered for
-            matchup
-          required: false
-          schema:
-            type: integer
-          example: 5
-        - in: query
-          name: tt
-          description: |
-            Tolerance in time (seconds) when comparing two measurements.
-          required: false
-          schema:
-            type: integer
-            default: 86400
-          example: 86400
-        - in: query
-          name: rt
-          description: |
-            Tolerance in radius (meters) when comparing two
-            measurements.
-          required: false
-          schema:
-            type: number
-            default: 1000.0
-          example: 1000.0
-        - in: query
-          name: parameter
-          description: |
-            The parameter of interest used for the match up.
-          required: false
-          schema:
-            type: string
-            enum: ['sst', 'sss', 'wind']
-            default: sst
-          example: sst
-        - in: query
-          name: matchOnce
-          description: |
-            True/False flag used to determine if more than one match
-            per primary point is returned. If true, only the nearest
-            point will be returned for each primary point. If false,
-            all points within the tolerances will be returned for each
-            primary point.
-          required: false
-          schema:
-            type: boolean
-            default: false
-          example: false
-        - in: query
-          name: resultSizeLimit
-          description: |
-            Optional integer value that limits the number of results
-            returned from the matchup. If the number of primary matches
-            is greater than this limit, the service will respond with
-            (HTTP 202 Accepted) and an empty response body. A value of
-            0 means return all results.
-          required: false
-          schema:
-            type: integer
-            default: 500
-          example: 500
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MatchupResponse'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   /match_spark:
     get:
-      summary: Execute matchup request
+      summary: Execute matchup request (AWS insitu)
       operationId: matchup
+      description: Endpoint to execute matchup request. If secondary dataset is insitu, use AWS insitu API.
       tags:
         - Matchup
       parameters:
@@ -286,6 +127,164 @@ paths:
           required: false
           schema:
             type: string
+            default: sst
+          example: sst
+        - in: query
+          name: matchOnce
+          description: |
+            True/False flag used to determine if more than one match
+            per primary point is returned. If true, only the nearest
+            point will be returned for each primary point. If false,
+            all points within the tolerances will be returned for each
+            primary point.
+          required: false
+          schema:
+            type: boolean
+            default: false
+          example: false
+        - in: query
+          name: resultSizeLimit
+          description: |
+            Optional integer value that limits the number of results
+            returned from the matchup. If the number of primary matches
+            is greater than this limit, the service will respond with
+            (HTTP 202 Accepted) and an empty response body. A value of
+            0 means return all results.
+          required: false
+          schema:
+            type: integer
+            default: 500
+          example: 500
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MatchupResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /match_spark_doms:
+    get:
+      summary: Execute matchup request (DOMS insitu)
+      operationId: matchup_doms
+      description: Endpoint to execute matchup request. If secondary dataset is insitu, use DOMS insitu API.
+      tags:
+        - Matchup
+      parameters:
+        - in: query
+          name: primary
+          description: |
+            The primary dataset used to find matches for. One of the
+            satellite "shortName" as supplied by /domslist endpoint.
+          required: true
+          schema:
+            type: string
+            x-dspopulate:
+             - satellite
+          example: avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020
+        - in: query
+          name: secondary
+          description: |
+            The dataset(s) being searched for measurements that match
+            the measurements in primary. One or more (comma-separated)
+            of the insitu or satellite "name" as supplied by
+            https://doms.jpl.nasa.gov/domslist
+          required: true
+          schema:
+            type: string
+          example: icoads
+        - in: query
+          name: startTime
+          description: |
+            Starting time in format YYYY-MM-DDTHH:mm:ssZ or seconds
+            since epoch
+          required: true
+          schema:
+            type: string
+            format: date-time
+          example: '2012-09-25T00:00:00Z'
+        - in: query
+          name: endTime
+          description: |
+            Ending time in format YYYY-MM-DDTHH:mm:ssZ or seconds
+            since epoch
+          required: true
+          schema:
+            type: string
+            format: date-time
+          example: '2012-09-30T23:59:59Z'
+        - in: query
+          name: b
+          description: |
+            Minimum (Western) Longitude, Minimum (Southern) Latitude,
+            Maximum (Eastern) Longitude, Maximum (Northern) Latitude
+          required: true
+          schema:
+            type: string
+          example: -45,15,-30,30
+        - in: query
+          name: platforms
+          description: Platforms to include for matchup consideration
+          required: true
+          schema:
+            type: string
+          example: 1,2,3,4,5,6,7,8,9
+        - in: query
+          name: depthMin
+          description: |
+            Minimum depth of measurements allowed to be considered for
+            matchup
+          required: false
+          schema:
+            type: integer
+          example: 0
+        - in: query
+          name: depthMax
+          description: |
+            Maximum depth of measurements allowed to be considered for
+            matchup
+          required: false
+          schema:
+            type: integer
+          example: 5
+        - in: query
+          name: tt
+          description: |
+            Tolerance in time (seconds) when comparing two measurements.
+          required: false
+          schema:
+            type: integer
+            default: 86400
+          example: 86400
+        - in: query
+          name: rt
+          description: |
+            Tolerance in radius (meters) when comparing two
+            measurements.
+          required: false
+          schema:
+            type: number
+            default: 1000.0
+          example: 1000.0
+        - in: query
+          name: parameter
+          description: |
+            The parameter of interest used for the match up.
+          required: false
+          schema:
+            type: string
+            enum: ['sst', 'sss', 'wind']
             default: sst
           example: sst
         - in: query


### PR DESCRIPTION
- Fixed openapi issues that was causing unusual swagger behavior
- Updated `/domslist` to use AWS insitu datasets rather than DOMS
- Updated `matchup_spark` to use the above endpoint so insitu datasets are auto populated in secondary dropdown
- Removed dropdown from `matchup_doms` endpoint secondary dropdown
- Added additional language to openapi spec to clarify which insitu API is being used which each matchup endpoint
- Added extra logs to capture additional timing metrics on AWS insitu performance  

(deployment in progress)