### PR TITLE
Fix for null count field in return for matchup_spark request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - Fix failing test_matchup unit test
+- Fixed null value for count in matchup response
 ### Security

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -280,7 +280,7 @@ class Matchup(NexusCalcSparkHandler):
             result = DomsQueryResults(results=None, args=args, details=details, bounds=None, count=None,
                                       computeOptions=None, executionId=execution_id, status_code=202)
         else:
-            result = DomsQueryResults(results=matches, args=args, details=details, bounds=None, count=None,
+            result = DomsQueryResults(results=matches, args=args, details=details, bounds=None, count=len(matches),
                                       computeOptions=None, executionId=execution_id)
 
         return result


### PR DESCRIPTION
Set to be the length of the matches passed as results.

Ran a quick test and it seems to be working (not null anymore and equal to number of matches returned)