### PR TITLE
Add metadata to remote coll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- SDAP-388: Enable SDAP to proxy/redirect to alternate SDAP
 - SDAP-372: Updated matchup algorithm to point to AWS insitu API endpoint
 - SDAP-372: Added new matchup endpoint `match_spark_doms` that points to DOMS insitu endpoint
 - SDAP-372: Updated `match_spark_doms` to interface with samos_cdms endpoint 

--- a/analysis/tests/redirect/test_RemoteSDAPCache.py
+++ b/analysis/tests/redirect/test_RemoteSDAPCache.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest import mock
+import requests
+
+from webservice.redirect import RemoteSDAPCache
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+def mocked_requests_get(*asgs, **kwargs):
+    json_data = [
+      {
+        "shortName": "PM25",
+        "title": "PM25",
+        "tileCount": 21515,
+        "start": 1514818800.0,
+        "end": 1640991600.0,
+        "iso_start": "2018-01-01T15:00:00+0000",
+        "iso_end": "2021-12-31T23:00:00+0000"
+      }
+    ]
+    return MockResponse(json_data, 200)
+
+
+def mocked_requests_get_timeout(*asgs, **kwargs):
+    raise requests.exceptions.ConnectTimeout()
+
+
+class MyTestCase(unittest.TestCase):
+
+    @mock.patch('requests.get', side_effect=mocked_requests_get)
+    def test_get(self, mock_get):
+        remote_sdap_cache = RemoteSDAPCache()
+
+        collection = remote_sdap_cache.get('https://aq-sdap.stcenter.net/nexus/', 'PM25')
+        self.assertEqual(collection["start"], 1514818800.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/analysis/webservice/algorithms/DataSeriesList.py
+++ b/analysis/webservice/algorithms/DataSeriesList.py
@@ -49,8 +49,7 @@ class DataSeriesListCalcHandlerImpl(NexusCalcHandler):
             def toJson(self):
                 return json.dumps(self.result)
 
-        #collection_list = self._get_tile_service().get_dataseries_list()
-        collection_list = []
+        collection_list = self._get_tile_service().get_dataseries_list()
 
         # add remote collections
         if self._remote_collections:

--- a/analysis/webservice/nexus_tornado/app_builders/HandlerArgsBuilder.py
+++ b/analysis/webservice/nexus_tornado/app_builders/HandlerArgsBuilder.py
@@ -4,7 +4,13 @@ from .SparkContextBuilder import SparkContextBuilder
 
 
 class HandlerArgsBuilder:
-    def __init__(self, max_request_threads, tile_service_factory, algorithm_config, remote_collections):
+    def __init__(
+            self,
+            max_request_threads,
+            tile_service_factory,
+            algorithm_config,
+            remote_collections=None
+    ):
         self.request_thread_pool = tornado.concurrent.futures.ThreadPoolExecutor(max_request_threads)
         self.tile_service_factory = tile_service_factory
         self.algorithm_config = algorithm_config
@@ -22,7 +28,7 @@ class HandlerArgsBuilder:
 
     @staticmethod
     def handler_needs_remote_collections(class_wrapper):
-        return class_wrapper == webservice.algorithms.DataSeriesList.D
+        return class_wrapper == webservice.algorithms.DataSeriesList.DataSeriesListCalcHandlerImpl
 
     def get_args(self, clazz_wrapper):
         args = dict(
@@ -37,7 +43,7 @@ class HandlerArgsBuilder:
         if self.handler_needs_algorithm_config(clazz_wrapper):
             args['config'] = self.algorithm_config
 
-        if clazz_wrapper == webservice.algorithms.DataSeriesList.DataSeriesListCalcHandlerImpl:
+        if self.handler_needs_remote_collections(clazz_wrapper):
             args['remote_collections'] = self.remote_collections
 
         return args

--- a/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
+++ b/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
@@ -30,7 +30,7 @@ class NexusAppBuilder:
                 r'/apidocs/(.*)', tornado.web.StaticFileHandler,
                 {'path': str(apidocs_path), "default_filename": "index.html"}))
 
-    def set_modules(self, module_dir, algorithm_config, remote_collections, max_request_threads=4):
+    def set_modules(self, module_dir, algorithm_config, remote_collections=None, max_request_threads=4):
         for moduleDir in module_dir:
             self.log.info("Loading modules from %s" % moduleDir)
             importlib.import_module(moduleDir)
@@ -44,7 +44,7 @@ class NexusAppBuilder:
             max_request_threads,
             tile_service_factory,
             algorithm_config,
-            remote_collections
+            remote_collections=remote_collections
         )
 
         for clazzWrapper in NexusHandler.AVAILABLE_HANDLERS:

--- a/analysis/webservice/redirect/RedirectHandler.py
+++ b/analysis/webservice/redirect/RedirectHandler.py
@@ -4,6 +4,7 @@ from webservice.webmodel.RequestParameters import RequestParameters
 
 logger = logging.getLogger(__name__)
 
+
 class RedirectHandler(tornado.web.RequestHandler):
 
     def initialize(self, redirected_collections=None):

--- a/analysis/webservice/redirect/RemoteSDAPCache.py
+++ b/analysis/webservice/redirect/RemoteSDAPCache.py
@@ -1,8 +1,10 @@
 import requests
+import logging
 from datetime import datetime
 from datetime import timedelta
 from dataclasses import dataclass
 
+logger = logging.getLogger(__name__)
 
 @dataclass
 class RemoteSDAPList:
@@ -23,6 +25,7 @@ class RemoteSDAPCache:
         try:
             r = requests.get(list_url, timeout=timeout)
             if r.status_code == 200:
+                logger.info("Caching list for sdap %s: %s", list_url, r.text)
                 self.sdap_lists[url] = RemoteSDAPList(
                     list=r.json(),
                     outdated_at=datetime.now()+timedelta(seconds=max_age)
@@ -38,7 +41,7 @@ class RemoteSDAPCache:
             self._add(stripped_url)
 
         for collection in self.sdap_lists[stripped_url].list:
-            if collection['shortName'] == short_name:
+            if 'shortName' in collection and collection['shortName'] == short_name:
                 return collection
 
         raise CollectionNotFound("collection %s has not been found in url %s", short_name, stripped_url)

--- a/analysis/webservice/redirect/RemoteSDAPCache.py
+++ b/analysis/webservice/redirect/RemoteSDAPCache.py
@@ -1,0 +1,42 @@
+import requests
+from datetime import datetime
+from datetime import timedelta
+from dataclasses import dataclass
+
+
+@dataclass
+class RemoteSDAPList:
+    list: dict
+    outdated_at: datetime
+
+
+class CollectionNotFound(Exception):
+    pass
+
+
+class RemoteSDAPCache:
+    def __init__(self):
+        self.sdap_lists = {}
+
+    def _add(self, url, timeout=2, max_age=3600*24):
+        list_url = f"{url}/list"
+        r = requests.get(list_url, timeout=timeout)
+        if r.status_code == 200:
+            self.sdap_lists[url] = RemoteSDAPList(
+                list=r.json(),
+                outdated_at=datetime.now()+timedelta(seconds=max_age)
+            )
+        else:
+            raise CollectionNotFound("url %s was not reachable, responded with status %s", list_url, r.status_code)
+
+    def get(self, url, short_name):
+        stripped_url = url.strip('/')
+        if stripped_url not in self.sdap_lists or self.sdap_lists[stripped_url].outdated_at>datetime.now():
+            self._add(stripped_url)
+
+        for collection in self.sdap_lists[stripped_url].list:
+            if collection['shortName'] == short_name:
+                return collection
+
+        raise CollectionNotFound("collection %s has not been found in url %s", short_name, stripped_url)
+

--- a/analysis/webservice/redirect/__init__.py
+++ b/analysis/webservice/redirect/__init__.py
@@ -1,2 +1,4 @@
 from .RedirectHandler import RedirectHandler
 from .RemoteCollectionMatcher import RemoteCollectionMatcher
+from .RemoteSDAPCache import RemoteSDAPCache
+from .RemoteSDAPCache import CollectionNotFound

--- a/data-access/requirements.txt
+++ b/data-access/requirements.txt
@@ -1,6 +1,7 @@
 cassandra-driver==3.24.0
 pysolr==3.9.0
-elasticsearch
+elasticsearch==8.3.1
+urllib3==1.26.2
 requests
 nexusproto
 Shapely

--- a/helm/templates/webapp.yml
+++ b/helm/templates/webapp.yml
@@ -16,7 +16,7 @@ spec:
     - --cassandra-username={{ include "nexus.credentials.cassandra.username" . }}
     - --cassandra-password={{ include "nexus.credentials.cassandra.password" . }}
     - --solr-host={{ include "nexus.urls.solr" . }}
-    - --collections-path={{ include "nexus.collectionsConfig.mountPath" . }}/collections-config.yaml
+    - --collections-path={{ include "nexus.collectionsConfig.mountPath" . }}/collections.yml
   sparkVersion: "3.1.1"
   volumes:
     - name: collections-config-volume
@@ -35,7 +35,7 @@ spec:
 {{ .Values.webapp.distributed.driver | toYaml | indent 4 }}
     labels:
       version: 3.1.1
-  serviceAccount: spark-serviceaccount
+    serviceAccount: spark-serviceaccount
   executor:
 {{ .Values.webapp.distributed.executor| toYaml | indent 4 }}
     labels:


### PR DESCRIPTION
This pull request completes ticket  https://issues.apache.org/jira/browse/SDAP-388 by providing metadata of the remote collections in the /list end-point.

The remote metadata is cached for 24 hours so to avoid latency on the user end. Note that the list result itself is cached for 1hour.

The implemented feature is deployed on https://aqacf.jpl.nasa.gov/nexus//list