### PR TITLE
Fix satellite to satellite matchup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix failing test_matchup unit test
 - Fixed null value for count in matchup response
 - SDAP-371: Fixed DOMS subset endpoint
+- Fixed issue where satellite satellite matchups failed
+- Fixed issue where null results were returned if more than "resultSizeLimit" matches are found
+- Fixed issue where satellite to satellite matchups with the same dataset don't return the expected result
 ### Security

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -277,12 +277,13 @@ class Matchup(NexusCalcSparkHandler):
 
         threading.Thread(target=do_result_insert).start()
 
-        if 0 < result_size_limit < len(matches):
-            result = DomsQueryResults(results=None, args=args, details=details, bounds=None, count=None,
-                                      computeOptions=None, executionId=execution_id, status_code=202)
-        else:
-            result = DomsQueryResults(results=matches, args=args, details=details, bounds=None, count=len(matches),
-                                      computeOptions=None, executionId=execution_id)
+        # Get only the first "result_size_limit" results
+        matches = matches[0:result_size_limit]
+
+        result = DomsQueryResults(results=matches, args=args,
+                                  details=details, bounds=None,
+                                  count=len(matches), computeOptions=None,
+                                  executionId=execution_id)
 
         return result
 
@@ -582,7 +583,12 @@ def spark_matchup_driver(tile_ids, bounding_wkt, primary_ds_name, secondary_ds_n
             lat1, lon1 = (primary.latitude, primary.longitude)
             lat2, lon2 = (matchup.latitude, matchup.longitude)
             az12, az21, distance = wgs84_geod.inv(lon1, lat1, lon2, lat2)
-            return distance
+            return distance, time_dist(primary, matchup)
+
+        def time_dist(primary, matchup):
+            primary_time = iso_time_to_epoch(primary.time)
+            matchup_time = iso_time_to_epoch(matchup.time)
+            return abs(primary_time - matchup_time)
 
         rdd_filtered = rdd_filtered \
             .map(lambda primary_matchup: tuple([primary_matchup[0], tuple([primary_matchup[1], dist(primary_matchup[0], primary_matchup[1])])])) \
@@ -635,10 +641,11 @@ def tile_to_edge_points(tile):
             data = [tile.data[tuple(idx)]]
 
         edge_point = {
-            'point': f'Point({tile.longitudes[idx[2]]} {tile.latitudes[idx[1]]})',
+            'latitude': tile.latitudes[idx[1]],
+            'longitude': tile.longitudes[idx[2]],
             'time': datetime.utcfromtimestamp(tile.times[idx[0]]).strftime('%Y-%m-%dT%H:%M:%SZ'),
             'source': tile.dataset,
-            'platform': None,
+            'platform': 'orbiting satellite',
             'device': None,
             'fileurl': tile.granule,
             'variables': tile.variables,


### PR DESCRIPTION
- Nga was seeing a 500 error when doing satellite to satellite matchup
  - Fixed satellite to satellite matchup failure -- was due to ` 'platform': None,` line
- Nga's request was returning "null" instead of data array, even after fixing above error
  - Changed behavior where, if > `resultsSizeLimit` results are found, the first `resultsSizeLimit` are returned, rather than returning "None"
- Nga's request was not returning expected results. The primary/secondary points were not identical, as expected.
  - This is due to the behavior of `matchOnce`. If `matchOnce` is selected, only one secondary point is returned. The secondary point that is chosen is the point that is closest to the primary point, spatially.
  - Updated this to choose the point based on both space AND time. I'm trying to think if there are any scenarios this wouldn't work?