### PR TITLE
SDAP-397: Requested matchup updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix failing test_matchup unit test
 - Fixed null value for count in matchup response
 - SDAP-371: Fixed DOMS subset endpoint
+- SDAP-397: Added depth to matchup insitu output
+- SDAP-397: Pull ID from insitu api response for matchup
+- SDAP-397: Added null unit field for later use in matchup
 ### Security

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -517,10 +517,12 @@ class DomsPoint(object):
             ) if var_value])
         point.data = data
 
-        try:
-            point.data_id = str(edge_point['id'])
-        except KeyError:
-            point.data_id = "%s:%s:%s" % (point.time, point.longitude, point.latitude)
+        if 'id' in edge_point:
+            point.data_id = edge_point['id']
+        elif 'platform' in edge_point and 'id' in edge_point['platform']:
+            point.data_id = edge_point['platform']['id']
+        else:
+            point.data_id = f'{point.time}:{point.longitude}:{point.latitude}'
 
         return point
 

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -490,7 +490,8 @@ class DomsPoint(object):
             'wind_to_direction_quality',
             'eastward_wind',
             'northward_wind',
-            'wind_component_quality'
+            'wind_component_quality',
+            'depth'
         ]
         data = []
         # This is for in-situ secondary points

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-
+from typing import Optional
 import json
 import logging
 import threading
@@ -326,10 +326,13 @@ class DataPoint:
     exist in the source data file.
     :attribute variable_value: value at some point for the given
         variable.
+    :attribute variable_unit: Unit of the measurement. Will be None if
+    no unit is known.
     """
     variable_name: str = None
     cf_variable_name: str = None
     variable_value: float = None
+    variable_unit: Optional[str] = None
 
 
 class DomsPoint(object):
@@ -387,7 +390,8 @@ class DomsPoint(object):
                 data.append(DataPoint(
                     variable_name=variable.variable_name,
                     variable_value=data_val,
-                    cf_variable_name=variable.standard_name
+                    cf_variable_name=variable.standard_name,
+                    variable_unit=None
                 ))
         point.data = data
 
@@ -500,7 +504,8 @@ class DomsPoint(object):
             if val:
                 data.append(DataPoint(
                     variable_name=name,
-                    variable_value=val
+                    variable_value=val,
+                    variable_unit=None
                 ))
 
 
@@ -510,7 +515,8 @@ class DomsPoint(object):
             data.extend([DataPoint(
                 variable_name=variable.variable_name,
                 variable_value=var_value,
-                cf_variable_name=variable.standard_name
+                cf_variable_name=variable.standard_name,
+                variable_unit=None
             ) for var_value, variable in zip(
                 edge_point['var_values'],
                 edge_point['variables']


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SDAP-397

- Added depth to matchup insitu output
  - Added in the "data" field (see example below). Is this a desirable location for this value?
- Pull ID from insitu api response for matchup
  - Using ID from insitu `platforms` dict. That value doesn't seem unique though, so I'm not sure if there's a better field.
- Added null unit field for later use in matchup
  - This metadata doesn't exist in the insitu API or satellite metadata so just using null for now.

Notice I don't have a change for the last bullet "numInSituRecords and numGriddedChecked are both zero in completed query...". Adding the behavior described from Doms would be a significant change, so I'd like to discuss with the team if this is indeed the desired behavior and if there's value in this field.

Example request:
```
{{big_data_url}}/match_spark?primary=MUR25-JPL-L4-GLOB-v04.2&startTime=2018-09-24T00:00:00Z&endTime=2018-09-30T00:00:00Z&tt=2592000&rt=1000&b=160,-30,180,-25&depthMin=0&depthMax=5&matchOnce=true&secondary=ICOADS%20Release%203.0&resultSizeLimit=6000&platforms=42
```

Example output (truncated):

```json
{
    "executionId": "8943d0a6-2513-4df1-83fb-536f1050fde8",
    "data": [
        {
            "platform": "orbiting satellite",
            "device": "radiometers",
            "lon": "179.375",
            "lat": "-27.125",
            "point": "Point(179.375 -27.125)",
            "time": 1537779600,
            "fileurl": "20180924090000-JPL-L4_GHRSST-SSTfnd-MUR25-GLOB-v02.0-fv04.2.nc",
            "id": "3e1ed916-5681-3a33-8688-d6a70ec080eb[[0, 11, 27]]",
            "source": "MUR25-JPL-L4-GLOB-v04.2",
            "primary": [
                {
                    "variable_name": "analysed_sst",
                    "cf_variable_name": "sea_surface_foundation_temperature",
                    "variable_value": 20.381988525390625,
                    "variable_unit": null
                }
            ],
            "matches": [
                {
                    "platform": "42",
                    "device": null,
                    "lon": "179.38",
                    "lat": "-27.12",
                    "point": "Point(179.38 -27.12)",
                    "time": 1537624800,
                    "fileurl": null,
                    "id": "55948",
                    "source": "ICOADS Release 3.0",
                    "secondary": [
                        {
                            "variable_name": "sea_water_temperature",
                            "cf_variable_name": null,
                            "variable_value": 19.8,
                            "variable_unit": null
                        },
                        {
                            "variable_name": "sea_water_temperature_quality",
                            "cf_variable_name": null,
                            "variable_value": 1,
                            "variable_unit": null
                        },
                        {
                            "variable_name": "depth",
                            "cf_variable_name": null,
                            "variable_value": -99999.0,
                            "variable_unit": null
                        }
                    ]
                }
            ]
        }
    ],
    "params": {
        "primary": "MUR25-JPL-L4-GLOB-v04.2",
        "matchup": "ICOADS Release 3.0",
        "startTime": 1537747200,
        "endTime": 1538265600,
        "bbox": "160,-30,180,-25",
        "timeTolerance": 2592000,
        "radiusTolerance": 1000.0,
        "platforms": "42",
        "parameter": null,
        "depthMin": 0.0,
        "depthMax": 5.0
    },
    "bounds": {},
    "count": 54,
    "details": {
        "timeToComplete": 101,
        "numInSituRecords": 0,
        "numInSituMatched": 54,
        "numGriddedChecked": 0,
        "numGriddedMatched": 54
    }
}
```
