### PR TITLE
Fixed error causing timeSeriesSpark to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,4 +32,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where satellite to satellite matchups with the same dataset don't return the expected result
 - Fixed CSV and NetCDF matchup output bug
 - Fixed NetCDF output switching latitude and longitude
+- Fixed import error causing `/timeSeriesSpark` queries to fail.
 ### Security

--- a/analysis/webservice/redirect/RedirectHandler.py
+++ b/analysis/webservice/redirect/RedirectHandler.py
@@ -1,4 +1,5 @@
-import tornado
+import tornado.web
+import tornado.gen
 import logging
 from webservice.webmodel.RequestParameters import RequestParameters
 


### PR DESCRIPTION
It appeared to have been caused by an import issue in RedirectHandler.py

Updated import statements and tested with local SDAP. Verified results against SDAP image preceding the error.