### PR TITLE
Matchup domsresults bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-398: Added script for regression tests.
 - Matchup validates insitu parameter using insitu API schema endpoint
 - Added domsresults endpoint to openapi spec
+- Added markdown table to matchup `platform` param in openapi spec
 ### Changed
 - SDAP-390: Changed `/doms` to `/cdms` and `doms_reader.py` to `cdms_reader.py`
 - domslist endpoint points to AWS insitu instead of doms insitu
@@ -40,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed CSV and NetCDF matchup output bug
 - Fixed NetCDF output switching latitude and longitude
 - Fixed import error causing `/timeSeriesSpark` queries to fail.
+- Fixed bug where domsresults no longer worked after successful matchup
+- Fixed certificate error in Dockerfile
 ### Security
 
 

--- a/analysis/webservice/algorithms/doms/ResultsStorage.py
+++ b/analysis/webservice/algorithms/doms/ResultsStorage.py
@@ -145,10 +145,10 @@ class ResultsStorage(AbstractResultsContainer):
         """
         self._session.execute(cql, (
             execution_id,
-            stats["numGriddedMatched"],
-            stats["numGriddedChecked"],
-            stats["numInSituMatched"],
-            stats["numInSituRecords"],
+            stats["numPrimaryMatched"],
+            None,
+            stats["numSecondaryMatched"],
+            None,
             stats["timeToComplete"]
         ))
 

--- a/analysis/webservice/algorithms_spark/MatchupDoms.py
+++ b/analysis/webservice/algorithms_spark/MatchupDoms.py
@@ -266,10 +266,8 @@ class MatchupDoms(NexusCalcSparkHandler):
         total_values = sum(len(v) for v in spark_result.values())
         details = {
             "timeToComplete": int((end - start).total_seconds()),
-            "numInSituRecords": 0,
-            "numInSituMatched": total_values,
-            "numGriddedChecked": 0,
-            "numGriddedMatched": total_keys
+            "numSecondaryMatched": total_values,
+            "numPrimaryMatched": total_keys
         }
 
         matches = MatchupDoms.convert_to_matches(spark_result)

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -78,7 +78,11 @@ paths:
           example: -45,15,-30,30
         - in: query
           name: platforms
-          description: Platforms to include for matchup consideration. Platform depends on which insitu dataset is selected. See `/get_cdms_schema` endpoint for a list of valid platform ids.
+          description: |
+            Platforms to include for matchup consideration. Platform
+            depends on which insitu dataset is selected. See
+            [/get_cdms_schema](https://doms.jpl.nasa.gov/insitu/1.0/cdms_schema)
+            endpoint for a list of valid platform ids.
           required: true
           schema:
             type: string
@@ -124,8 +128,9 @@ paths:
           name: parameter
           description: |
             The parameter of interest used for the match up. This is
-            only used for insitu measurements. See `/cdmsschema` endpoint
-            for a list of valid options.
+            only used for insitu measurements. See
+            [/get_cdms_schema](https://doms.jpl.nasa.gov/insitu/1.0/cdms_schema)
+            endpoint for a list of valid options.
           required: false
           schema:
             type: string

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -94,7 +94,7 @@ paths:
             | 30          | ship                                    | [Link](http://vocab.nerc.ac.uk/collection/L06/current/30/) |
             | 41          | moored surface buoy                     | [Link](http://vocab.nerc.ac.uk/collection/L06/current/41/) |
             | 42          | drifting surface float                  | [Link](http://vocab.nerc.ac.uk/collection/L06/current/42/) |
-            </details
+            </details>
 
           required: true
           schema:

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -80,9 +80,22 @@ paths:
           name: platforms
           description: |
             Platforms to include for matchup consideration. Platform
-            depends on which insitu dataset is selected. See
-            [/get_cdms_schema](https://doms.jpl.nasa.gov/insitu/1.0/cdms_schema)
-            endpoint for a list of valid platform ids.
+            depends on which insitu dataset is selected. Use platform ID
+            in the matchup query.
+
+            <details>
+              <summary>Expand to see a list of valid platforms IDs:</summary>
+            | Platform ID | Platform Name                           | Web Link                                                   |
+            | ----------- | --------------------------------------- | ---------------------------------------------------------- |
+            | 3B          | autonomous surface water vehicle        | [Link](http://vocab.nerc.ac.uk/collection/L06/current/3B/) |
+            | 0           | unknown                                 | [Link](http://vocab.nerc.ac.uk/collection/L06/current/0/)  |
+            | 16          | offshore structure                      | [Link](http://vocab.nerc.ac.uk/collection/L06/current/16/) |
+            | 17          | coastal structure                       | [Link](http://vocab.nerc.ac.uk/collection/L06/current/17/) |
+            | 30          | ship                                    | [Link](http://vocab.nerc.ac.uk/collection/L06/current/30/) |
+            | 41          | moored surface buoy                     | [Link](http://vocab.nerc.ac.uk/collection/L06/current/41/) |
+            | 42          | drifting surface float                  | [Link](http://vocab.nerc.ac.uk/collection/L06/current/42/) |
+            </details
+
           required: true
           schema:
             type: string

--- a/docker/nexus-webapp/Dockerfile
+++ b/docker/nexus-webapp/Dockerfile
@@ -32,7 +32,8 @@ ENV  \
     SPARK_HOME=/opt/spark \
     PYSPARK_DRIVER_PYTHON=/opt/conda/bin/python3.8 \
     PYSPARK_PYTHON=/opt/conda/bin/python3.8 \
-    LD_LIBRARY_PATH=/usr/lib
+    LD_LIBRARY_PATH=/usr/lib \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
 RUN apk add --update --no-cache \
     bzip2 \


### PR DESCRIPTION
* Fixed bug introduced in the last PR causing `domsresults` to no longer work. This was because the `details` field names were updated, but the code that inserts results into the database was not. I've updated the code that inserts the details into the database to look for the new field names. `None` is being used for `stats["numGriddedChecked"]` and `stats["numInsituChecked"]` because otherwise we'd need to change the db schema which would cause issues with many existing SDAP deployments. 
* Added link to CDMS Schema endpoint in Swagger in the `parameter` and `platforms` field descriptions
* Added env var `REQUESTS_CA_BUNDLE` env var to Dockerfile. Building the docker image suddenly stopped working the other day with error `Could not find a suitable TLS CA certificate bundle`, so this is a fix for that. Both myself and @kevinmarlis  have tested this fix.

These changes are deployed to the CDMS AWS `nexus-sit` environment. 

I tested the `domsresults` endpoint with both CDMS and DOMS matchup requests and was able to retrieve CSV results for both.
