### PR TITLE
SDAP-403: Remote timeout fix and HofMoeller bug fix

### DIFF
--- a/analysis/webservice/algorithms/HofMoeller.py
+++ b/analysis/webservice/algorithms/HofMoeller.py
@@ -55,7 +55,7 @@ class LongitudeHofMoellerCalculator(object):
         points_by_lon = itertools.groupby(data, key=lambda p: p.longitude)
 
         for lon, points_at_lon in points_by_lon:
-            values_at_lon = np.array([point.data_val for point in points_at_lon])
+            values_at_lon = np.array([point.data_vals for point in points_at_lon])
             stat['lons'].append({
                 'longitude': float(lon),
                 'cnt': len(values_at_lon),
@@ -81,7 +81,7 @@ class LatitudeHofMoellerCalculator(object):
         points_by_lat = itertools.groupby(data, key=lambda p: p.latitude)
 
         for lat, points_at_lat in points_by_lat:
-            values_at_lat = np.array([point.data_val for point in points_at_lat])
+            values_at_lat = np.array([point.data_vals for point in points_at_lat])
 
             stat['lats'].append({
                 'latitude': float(lat),

--- a/analysis/webservice/algorithms_spark/HofMoellerSpark.py
+++ b/analysis/webservice/algorithms_spark/HofMoellerSpark.py
@@ -71,7 +71,7 @@ class HofMoellerCalculator(object):
             points_by_coord = itertools.groupby(data, key=lambda p: p.longitude)
 
         for coord, points_at_coord in points_by_coord:
-            values_at_coord = np.array([[p.data_val,
+            values_at_coord = np.array([[p.data_vals,
                                          np.cos(np.radians(p.latitude))]
                                         for p in points_at_coord])
             vals = np.nan_to_num(values_at_coord[:, 0])

--- a/analysis/webservice/redirect/RemoteSDAPCache.py
+++ b/analysis/webservice/redirect/RemoteSDAPCache.py
@@ -31,9 +31,9 @@ class RemoteSDAPCache:
                     outdated_at=datetime.now()+timedelta(seconds=max_age)
                 )
             else:
-                raise CollectionNotFound("url %s was not reachable, responded with status %s", list_url, r.status_code)
-        except requests.exceptions.ConnectTimeout as e:
-            raise CollectionNotFound("url %s was not reachable in %i s",  list_url, timeout)
+                raise CollectionNotFound(f"url {list_url} was not reachable, responded with status {r.status_code}")
+        except (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout) as e:
+            raise CollectionNotFound(f"url {list_url} was not reachable in {timeout} s")
 
     def get(self, url, short_name):
         stripped_url = url.strip('/')
@@ -44,5 +44,4 @@ class RemoteSDAPCache:
             if 'shortName' in collection and collection['shortName'] == short_name:
                 return collection
 
-        raise CollectionNotFound("collection %s has not been found in url %s", short_name, stripped_url)
-
+        raise CollectionNotFound(f"collection {short_name} has not been found in url {stripped_url}")


### PR DESCRIPTION

On the AQ deployment we found a redirect bug that caused the AQ `/nexus/list` to crash when attempting to connect to a remote SDAP. The redirect code was catching `requests.exceptions.ConnectTimeout` exceptions but `requests.exceptions.ReadTimeout` exceptions could also be raised when the remote `/nexus/list` endpoint was unreachable.  This PR addresses that by including `requests.exceptions.ReadTimeout` in the except block. 

This PR also includes a fix to the HofMoeller algorithms. There was a change made to the name of the nexus point data_val variable (from point.data_val to point.data_vals) in nexus model.py's nexus_point_generator. The change in variable name was not updated in the HofMoeller algorithms, so this change is included in the PR.

The fix to the HofMoeller algorithms has been tested in SLCP's sit environment.