### PR TITLE
Insitu query logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Matchup returns numSecondary and numPrimary counts rather than insitu/gridded
 - SDAP-402: Changed matchup matchOnce logic to match multiple points if same time/space
 - Bumped ingress timeout in Helm chart to reflect AWS gateway timeout
+- Added logging message for start of insitu query + added status code & elapsed time to post query log message.
 ### Deprecated
 ### Removed
 - removed dropdown from matchup doms endpoint secondary param

--- a/analysis/webservice/algorithms/doms/insitu.py
+++ b/analysis/webservice/algorithms/doms/insitu.py
@@ -58,12 +58,15 @@ def query_insitu(dataset, variable, start_time, end_time, bbox, platform, depth_
     # Page through all insitu results
     next_page_url = insitu_endpoints.getEndpoint(provider)
     while next_page_url is not None and next_page_url != 'NA':
+        thetime = datetime.now()
+        logging.info("Starting insitu request")
+
         if session is not None:
             response = session.get(next_page_url, params=params)
         else:
             response = requests.get(next_page_url, params=params)
 
-        logging.info(f'Insitu request {response.url}')
+        logging.info(f'Insitu request {response.url} finished. Code: {response.status_code} Time: {str(datetime.now() - thetime)}')
 
         response.raise_for_status()
         insitu_page_response = response.json()

--- a/analysis/webservice/algorithms/doms/insitu.py
+++ b/analysis/webservice/algorithms/doms/insitu.py
@@ -5,6 +5,7 @@ import logging
 import requests
 from datetime import datetime
 from webservice.algorithms.doms import config as insitu_endpoints
+from urllib.parse import urlencode
 
 
 def query_insitu_schema():
@@ -60,7 +61,7 @@ def query_insitu(dataset, variable, start_time, end_time, bbox, platform, depth_
     next_page_url = insitu_endpoints.getEndpoint(provider)
     while next_page_url is not None and next_page_url != 'NA':
         thetime = datetime.now()
-        logging.info("Starting insitu request")
+        logging.info(f"Starting insitu request: {next_page_url}?{urlencode(params)}")
 
         if session is not None:
             response = session.get(next_page_url, params=params)

--- a/analysis/webservice/algorithms/doms/insitu.py
+++ b/analysis/webservice/algorithms/doms/insitu.py
@@ -61,7 +61,10 @@ def query_insitu(dataset, variable, start_time, end_time, bbox, platform, depth_
     next_page_url = insitu_endpoints.getEndpoint(provider)
     while next_page_url is not None and next_page_url != 'NA':
         thetime = datetime.now()
-        logging.info(f"Starting insitu request: {next_page_url}?{urlencode(params)}")
+        if params == {}:
+            logging.info(f"Starting insitu request: {next_page_url}")
+        else:
+            logging.info(f"Starting insitu request: {next_page_url}?{urlencode(params)}")
 
         if session is not None:
             response = session.get(next_page_url, params=params)


### PR DESCRIPTION
Improved the logging for insitu queries to show when the query starts + its URL and then when the query ends, its URL (for correlation), status code, and elapsed time.