### PR TITLE
Add second NCAR provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-400: Added NCAR insitu api to matchup
 - SDAP-405: Added SPURS AWS insitu api to matchup and new platform values to OpenAPI matchup spec
 - RabbitMQ monitor script used in Docker quickstart guide
+- Added new option for NCAR so either NCAR or JPL Insitu API can be specified
 ### Changed
 - SDAP-390: Changed `/doms` to `/cdms` and `doms_reader.py` to `cdms_reader.py`
 - domslist endpoint points to AWS insitu instead of doms insitu

--- a/analysis/webservice/algorithms/doms/config.py
+++ b/analysis/webservice/algorithms/doms/config.py
@@ -22,6 +22,17 @@ INSITU_PROVIDER_MAP = [
         'endpoint': 'https://cdms.ucar.edu/insitu/1.0/query_data_doms_custom_pagination',
         'projects': [
             {
+                'short_name': 'ICOADS_NCAR',
+                'name': 'ICOADS Release 3.0',
+                'platforms': ['0', '16', '17', '30', '41', '42']
+            }
+        ]
+    },
+    {
+        'name': 'NCAR',
+        'projects': [
+            {
+                'short_name': 'ICOADS_JPL',
                 'name': 'ICOADS Release 3.0',
                 'platforms': ['0', '16', '17', '30', '41', '42']
             }
@@ -159,12 +170,19 @@ except KeyError:
     pass
 
 
-def getEndpoint(provider_name=None):
-    if provider_name is None:
+def getEndpoint(provider_name=None, project_name=None):
+    if provider_name is None or project_name is None:
         return INSITU_API_ENDPOINT
 
-    provider = next((provider for provider in INSITU_PROVIDER_MAP
-                     if provider['name'] == provider_name), None)
+    provider = next((
+        provider for provider in INSITU_PROVIDER_MAP
+        for project in provider['projects']
+        if provider['name'] == provider_name
+        and (
+            project['name'] == project_name
+            or project.get('short_name') == project_name
+        )
+    ), None)
 
     if 'endpoint' in provider:
         return provider['endpoint']
@@ -194,8 +212,12 @@ def validate_insitu_params(provider_name, project_name, platform_name):
     if provider is None:
         return False
 
-    project = next((project for project in provider['projects']
-                    if project_name == project['name']), None)
+    project = next((
+        project for project in provider['projects']
+        if project_name == project['name']
+           or project_name == project.get('short_name')
+    ), None)
+
 
     if project is None:
         return False
@@ -204,8 +226,11 @@ def validate_insitu_params(provider_name, project_name, platform_name):
 
 
 def get_provider_name(project_name):
-    provider = next((provider for provider in INSITU_PROVIDER_MAP
-                     if project_name in map(lambda project: project['name'], provider['projects'])), None)
+    provider = next((
+        provider for provider in INSITU_PROVIDER_MAP
+        if project_name in map(lambda project: project['name'], provider['projects'])
+        or project_name in map(lambda project: project.get('short_name'), provider['projects'])
+    ), None)
 
     if provider is not None:
         return provider['name']
@@ -217,3 +242,19 @@ def get_provider_name(project_name):
     if provider is not None:
         return provider['name']
 
+
+def get_project_name(project_name):
+    """
+    Get project name, given either project name or short name.
+    """
+    project = next((
+        project for provider in INSITU_PROVIDER_MAP
+        for project in provider['projects']
+        if project.get('short_name') == project_name or project['name'] == project_name
+    ), None)
+
+    if project is not None:
+        return project['name']
+
+    # If not found, return input project name. DOMS insitu node will need this
+    return project_name

--- a/analysis/webservice/algorithms/doms/insitu.py
+++ b/analysis/webservice/algorithms/doms/insitu.py
@@ -38,6 +38,7 @@ def query_insitu(dataset, variable, start_time, end_time, bbox, platform, depth_
         pass
 
     provider = insitu_endpoints.get_provider_name(dataset)
+    project = insitu_endpoints.get_project_name(dataset)
 
     params = {
         'itemsPerPage': items_per_page,
@@ -47,7 +48,7 @@ def query_insitu(dataset, variable, start_time, end_time, bbox, platform, depth_
         'minDepth': depth_min,
         'maxDepth': depth_max,
         'provider': provider,
-        'project': dataset,
+        'project': project,
         'platform': platform,
     }
 
@@ -57,7 +58,7 @@ def query_insitu(dataset, variable, start_time, end_time, bbox, platform, depth_
     insitu_response = {}
 
     # Page through all insitu results
-    next_page_url = insitu_endpoints.getEndpoint(provider)
+    next_page_url = insitu_endpoints.getEndpoint(provider, dataset)
     while next_page_url is not None and next_page_url != 'NA':
         if session is not None:
             response = session.get(next_page_url, params=params)


### PR DESCRIPTION
Added a new provider for NCAR so either the NCAR insitu api or JPL insitu api can be specified. This wasn't really possible due to the way this was written so I had to add an extra field in the insitu config `short_name`. This is optional, and can be specified when executing matching and specifying the secondary dataset. 

With these changes, the following secondary ICOADS values can be provided:

- `ICOADS%20Release%203.0` Uses the NCAR In-Situ API (this is the old method which still works)
- `ICOADS_NCAR` Uses the NCAR In-Situ API
- `ICOADS_JPL` Uses the JPL In-Situ API

Once validated, I'd recommend we revert these changes as they won't be useful in a practical scenario.

---

Testing:

```bash
{{big_data_url}}/match_spark?primary=MUR25-JPL-L4-GLOB-v04.2&secondary=ICOADS%20Release%203.0&startTime=2017-07-01T00%3A00%3A00Z&endTime=2017-07-07T23%3A59%3A59Z&b=-100%2C20%2C-79%2C30&platforms=30&depthMin=-10&depthMax=10&tt=43200&rt=5000&matchOnce=false&resultSizeLimit=0
```

```json
    "details": {
        "timeToComplete": 72,
        "numSecondaryMatched": 258,
        "numPrimaryMatched": 101
    }
```

```bash
{{big_data_url}}/match_spark?primary=MUR25-JPL-L4-GLOB-v04.2&secondary=ICOADS_JPL&startTime=2017-07-01T00%3A00%3A00Z&endTime=2017-07-07T23%3A59%3A59Z&b=-100%2C20%2C-79%2C30&platforms=30&depthMin=-10&depthMax=10&tt=43200&rt=5000&matchOnce=false&resultSizeLimit=0
```

```json
    "details": {
        "timeToComplete": 83,
        "numSecondaryMatched": 218,
        "numPrimaryMatched": 82
    }
```

```bash
{{big_data_url}}/match_spark?primary=MUR25-JPL-L4-GLOB-v04.2&secondary=ICOADS_NCAR&startTime=2017-07-01T00%3A00%3A00Z&endTime=2017-07-07T23%3A59%3A59Z&b=-100%2C20%2C-79%2C30&platforms=30&depthMin=-10&depthMax=10&tt=43200&rt=5000&matchOnce=false&resultSizeLimit=0
```

```json
    "details": {
        "timeToComplete": 77,
        "numSecondaryMatched": 258,
        "numPrimaryMatched": 101
    }
```

Also confirmed through logs that the expected API is hit. Note: the NCAR matchup returns different results so we should definitely look into that.

Also tested with the `match_spark_doms` to make sure nothing was broken:

```json
{{big_data_url}}/domssubset?dataset=ASCATB-L2-Coastal&insitu=samos&startTime=2017-05-01T00%3A00%3A00Z&endTime=2017-05-14T23%3A59%3A59Z&b=-100%2C10%2C-79%2C-30&parameter=wind&depthMin=-10&depthMax=10&platforms=1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9
```

No errors occured. 

Also tested with unrelated `ASCATA-L2` -> shark matchup request, also worked as expected. 


