### PR TITLE
SDAP-406: Fix comparison stats bug in timeseriesspark algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed certificate error in Dockerfile
 - SDAP-403: Remote timeout fix and HofMoeller bug fix
 - Fixed matchup insitu query loading on import; loads when needed instead
+- SDAP-406: Fixed `/timeSeriesSpark`comparison stats bug
 ### Security
 
 

--- a/analysis/webservice/algorithms_spark/TimeSeriesSpark.py
+++ b/analysis/webservice/algorithms_spark/TimeSeriesSpark.py
@@ -317,13 +317,17 @@ class TimeSeriesSparkHandlerImpl(NexusCalcSparkHandler):
                 xy[item[1]["ds"]].append(item[1]["mean"])
 
         slope, intercept, r_value, p_value, std_err = stats.linregress(xy[0], xy[1])
-        comparisonStats = {
-            "slope": slope,
-            "intercept": intercept,
-            "r": r_value,
-            "p": p_value,
-            "err": std_err
-        }
+
+        if any(np.isnan([slope, intercept, r_value, p_value, std_err])):
+            comparisonStats = {}
+        else:
+            comparisonStats = {
+                "slope": slope,
+                "intercept": intercept,
+                "r": r_value,
+                "p": p_value,
+                "err": std_err
+            }
 
         return comparisonStats
 


### PR DESCRIPTION
This PR fixes a bug in the `/timeSeriesSpark` algorithm that would return NaNs in the comparison stats dictionary when comparing two datasets with only one overlapping date. 

ex: Under certain conditions there can be only a single date matchup between DS1 and DS2 which results in the linear regression algorithm used to compute the comparison stats returning NaNs. 

The fix (for now) is to check for NaNs in the results of the linear regression algorithm and set the comparison stats to an empty dictionary, following the precedent set when there are no matching dates. 

This has been tested in SLCP's deployment.