### PR TITLE
SDAP-407: Return depth in CSV and NETCDF matchup outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-405: Added SPURS AWS insitu api to matchup and new platform values to OpenAPI matchup spec
 - RabbitMQ monitor script used in Docker quickstart guide
 - Added new option for NCAR so either NCAR or JPL Insitu API can be specified
+- SDAP-407: Added depth to `/domsresults` endpoint
 ### Changed
 - SDAP-390: Changed `/doms` to `/cdms` and `doms_reader.py` to `cdms_reader.py`
 - domslist endpoint points to AWS insitu instead of doms insitu

--- a/analysis/webservice/algorithms/doms/BaseDomsHandler.py
+++ b/analysis/webservice/algorithms/doms/BaseDomsHandler.py
@@ -455,7 +455,7 @@ class DomsNetCDFValueWriter:
         timeVar[:] = self.time
 
         # Add depth variable, if present
-        if self.depth:
+        if self.depth and any(self.depth):
             depthVar = self.group.createVariable('depth', 'f4', ('dim',), fill_value=-32767.0)
             self.__enrichDepth(depthVar, self.__calcMin(self.depth), max(self.depth))
             depthVar[:] = self.depth

--- a/analysis/webservice/algorithms/doms/DomsInitialization.py
+++ b/analysis/webservice/algorithms/doms/DomsInitialization.py
@@ -164,6 +164,7 @@ class DomsInitializer:
               platform text,
               device text,
               measurement_values map<text, decimal>,
+              depth decimal,
               PRIMARY KEY (execution_id, is_primary, id)
             );
         """

--- a/analysis/webservice/algorithms/doms/ResultsStorage.py
+++ b/analysis/webservice/algorithms/doms/ResultsStorage.py
@@ -156,9 +156,9 @@ class ResultsStorage(AbstractResultsContainer):
 
         cql = """
            INSERT INTO doms_data
-                (id, execution_id, value_id, primary_value_id, x, y, source_dataset, measurement_time, platform, device, measurement_values, is_primary)
+                (id, execution_id, value_id, primary_value_id, x, y, source_dataset, measurement_time, platform, device, measurement_values, is_primary, depth)
            VALUES
-                (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
         insertStatement = self._session.prepare(cql)
         batch = BatchStatement()
@@ -189,9 +189,9 @@ class ResultsStorage(AbstractResultsContainer):
             result["platform"] if "platform" in result else None,
             result["device"] if "device" in result else None,
             dataMap,
-            1 if primaryId is None else 0
-        )
-                  )
+            1 if primaryId is None else 0,
+            result["depth"]
+        ))
 
         n = 0
         if "matches" in result:
@@ -283,7 +283,8 @@ class ResultsRetrieval(AbstractResultsContainer):
                 "source": row.source_dataset,
                 "device": row.device,
                 "platform": row.platform,
-                "time": row.measurement_time.replace(tzinfo=UTC)
+                "time": row.measurement_time.replace(tzinfo=UTC),
+                "depth": row.depth
             }
         for key in row.measurement_values:
             value = float(row.measurement_values[key])


### PR DESCRIPTION
[SDAP-407](https://issues.apache.org/jira/browse/SDAP-407)

Currently, depth is not being returned when the `/domsresults` endpoint is called. This is because depth is not stored in the database so that information is lost.

Added depth to the database, after matchup this field is now populated. Updated CSV and NetCDF conversion to make sure this field is present. 

Examples below. Please note the primary dataset is a satellite dataset which is why depth is null/not present. 

Also note that I generated these by running a local instance of Solr/Cassandra and included massively large tolerances to make sure a match would occur. The matches are not valid and were only used for testing purposes. 

```sh
/match_spark?tt=43200&primary=AVHRR_OI_L4_GHRSST_NCEI&secondary=ICOADS_JPL&startTime=2015-01-01T00%3A00%3A00Z&endTime=2018-04-05T00%3A00%3A00Z&rt=25000&b=-140%2C10%2C-110%2C40&platforms=30&depthMin=-5&depthMax=5&matchOnce=true&tt=999999999
```

[response.nc.txt](https://github.com/apache/incubator-sdap-nexus/files/9855618/response.nc.txt)
[response.csv](https://github.com/apache/incubator-sdap-nexus/files/9855620/response.csv)


