### PR TITLE
SDAP 412 - Solution to Duplicate Primary Issue in /match_spark Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `platforms` param optional in `/cdmssubset`, and removed int requirement
 - Updated OpenAPI specification for `/cdmssubset` to accurately reflect `platforms` and `parameter` field options.
 - SDAP-436: Added special case for handling Cassandra SwathMulti tiles with uniform time arrays
-- SDAP-412: Explicit definition of `__eq__` in matchup `DomsPoint` class. This prevents the duplicate primary points from appearing in the final results by merging them in the `combineByKey` step.
+- SDAP-412: Explicit definition of `__eq__` and `__hash__` in matchup `DomsPoint` class. This ensures all primary-secondary pairs with the same primary point are merged in the `combineByKey` step.
 ### Security
 
 ## [1.0.0] - 2022-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- SDAP-412: Explicit definition of `__eq__` in matchup `DomsPoint` class. This prevents the duplicate primary points from appearing in the final results by merging them in the `combineByKey` step.
+### Security
+
 ## [1.0.0] - 2022-11-22
 ### Added
 - SDAP-388: Enable SDAP to proxy/redirect to alternate SDAP
@@ -60,7 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed matchup insitu query loading on import; loads when needed instead
 - SDAP-406: Fixed `/timeSeriesSpark`comparison stats bug
 - Fixed excessive memory usage by `/cdmssubset`
-- SDAP-412: Explicit definition of `__eq__` in matchup `DomsPoint` class. This prevents the duplicate primary points from appearing in the final results by merging them in the `combineByKey` step.
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed matchup insitu query loading on import; loads when needed instead
 - SDAP-406: Fixed `/timeSeriesSpark`comparison stats bug
 - Fixed excessive memory usage by `/cdmssubset`
+- SDAP-412: Explicit definition of `__eq__` in matchup `DomsPoint` class. This prevents the duplicate primary points from appearing in the final results by merging them in the `combineByKey` step.
 ### Security
 
 

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -370,6 +370,24 @@ class DomsPoint(object):
     def __repr__(self):
         return str(self.__dict__)
 
+    def __eq__(self, other):
+        if not isinstance(other, DomsPoint):
+            return False
+
+        return self.time == other.time and \
+            self.longitude == other.longitude and \
+            self.latitude == other.latitude and \
+            self.depth == other.depth and \
+            self.data_id == other.data_id and \
+            self.data == other.data and \
+            self.source == other.source and \
+            self.platform == other.platform and \
+            self.device == other.device and \
+            self.file_url == other.file_url
+
+    def __hash__(self):
+        return hash(repr(self))
+
     @staticmethod
     def _variables_to_device(variables):
         """

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -367,34 +367,14 @@ class DomsPoint(object):
         self.device = None
         self.file_url = None
 
-        self.__hash = None
-
     def __repr__(self):
         return str(self.__dict__)
 
     def __eq__(self, other):
-        if not isinstance(other, DomsPoint):
-            return False
-
-        return self.time == other.time and \
-            self.longitude == other.longitude and \
-            self.latitude == other.latitude and \
-            self.depth == other.depth and \
-            self.data_id == other.data_id and \
-            self.data == other.data and \
-            self.source == other.source and \
-            self.platform == other.platform and \
-            self.device == other.device and \
-            self.file_url == other.file_url
+        return isinstance(other, DomsPoint) and other.data_id == self.data_id
 
     def __hash__(self):
-        self._compute_hash()
-        return self.__hash
-
-    def _compute_hash(self):
-        if self.__hash is None:
-            # self.__hash = hash(repr(self))
-            self.__hash = hash(self.data_id)
+        return hash(self.data_id) if self.data_id else id(self)
 
     @staticmethod
     def _variables_to_device(variables):
@@ -466,7 +446,6 @@ class DomsPoint(object):
 
         point.platform = 9
         point.device = DomsPoint._variables_to_device(tile.variables)
-        point._compute_hash()
         return point
 
     @staticmethod

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -367,11 +367,13 @@ class DomsPoint(object):
         self.device = None
         self.file_url = None
 
+        self.__id = id(self)
+
     def __repr__(self):
         return str(self.__dict__)
 
     def __eq__(self, other):
-        return isinstance(other, DomsPoint) and other.data_id == self.data_id
+        return isinstance(other, DomsPoint) and other.__id == self.__id
 
     def __hash__(self):
         return hash(self.data_id) if self.data_id else id(self)

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -367,6 +367,8 @@ class DomsPoint(object):
         self.device = None
         self.file_url = None
 
+        self.__hash = None
+
     def __repr__(self):
         return str(self.__dict__)
 
@@ -386,7 +388,13 @@ class DomsPoint(object):
             self.file_url == other.file_url
 
     def __hash__(self):
-        return hash(repr(self))
+        self._compute_hash()
+        return self.__hash
+
+    def _compute_hash(self):
+        if self.__hash is None:
+            # self.__hash = hash(repr(self))
+            self.__hash = hash(self.data_id)
 
     @staticmethod
     def _variables_to_device(variables):
@@ -458,6 +466,7 @@ class DomsPoint(object):
 
         point.platform = 9
         point.device = DomsPoint._variables_to_device(tile.variables)
+        point._compute_hash()
         return point
 
     @staticmethod


### PR DESCRIPTION
Prevents duplicate primary points from appearing in result of matchup by implementing object equality for `DomsPoint` class such that different `DomsPoint` objects that happen to correspond to the same primary point are merged in the `combineByKey` step.

This PR does not find/solve the root cause of this issue but does prevent it from effecting the final results.