### PR TITLE
cdmssubset bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed matchup insitu query loading on import; loads when needed instead
 - SDAP-406: Fixed `/timeSeriesSpark`comparison stats bug
 - Fixed excessive memory usage by `/cdmssubset`
+- Made `platforms` param optional in `/cdmssubset`, and removed int requirement
+- Updated OpenAPI specification for `/cdmssubset` to accurately reflect `platforms` and `parameter` field options.
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Made `platforms` param optional in `/cdmssubset`, and removed int requirement
+- Updated OpenAPI specification for `/cdmssubset` to accurately reflect `platforms` and `parameter` field options.
+### Security
+
 ## [1.0.0] - 2022-11-22
 ### Added
 - SDAP-388: Enable SDAP to proxy/redirect to alternate SDAP
@@ -60,8 +70,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed matchup insitu query loading on import; loads when needed instead
 - SDAP-406: Fixed `/timeSeriesSpark`comparison stats bug
 - Fixed excessive memory usage by `/cdmssubset`
-- Made `platforms` param optional in `/cdmssubset`, and removed int requirement
-- Updated OpenAPI specification for `/cdmssubset` to accurately reflect `platforms` and `parameter` field options.
 ### Security
 
 

--- a/analysis/webservice/algorithms/doms/subsetter.py
+++ b/analysis/webservice/algorithms/doms/subsetter.py
@@ -252,6 +252,7 @@ class DomsResultsRetrievalHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
                 data.append({
                     'latitude': result['latitude'],
                     'longitude': result['longitude'],
+                    'id': result['meta'],
                     'time': (datetime.strptime(result['time'], '%Y-%m-%dT%H:%M:%SZ') - datetime.fromtimestamp(0)).total_seconds(),
                     'data': data_points
                 })
@@ -295,7 +296,8 @@ class SubsetResult(NexusResults):
             headers = [
                 'longitude',
                 'latitude',
-                'time'
+                'time',
+                'id'
             ]
             data_variables = list(set([keys for result in results for keys in result['data'].keys()]))
             data_variables.sort()
@@ -306,6 +308,7 @@ class SubsetResult(NexusResults):
                 cols.append(result['longitude'])
                 cols.append(result['latitude'])
                 cols.append(datetime.utcfromtimestamp(result['time']).strftime('%Y-%m-%dT%H:%M:%SZ'))
+                cols.append(result['id'])
 
                 for var in data_variables:
                     cols.append(result['data'].get(var))

--- a/analysis/webservice/algorithms/doms/subsetter.py
+++ b/analysis/webservice/algorithms/doms/subsetter.py
@@ -311,7 +311,9 @@ class SubsetResult(NexusResults):
                 cols.append(result['longitude'])
                 cols.append(result['latitude'])
                 cols.append(datetime.utcfromtimestamp(result['time']).strftime('%Y-%m-%dT%H:%M:%SZ'))
-                cols.append(result.get('id'))
+
+                if 'id' in headers:
+                    cols.append(result.get('id'))
 
                 for var in data_variables:
                     cols.append(result['data'].get(var))

--- a/analysis/webservice/algorithms/doms/subsetter.py
+++ b/analysis/webservice/algorithms/doms/subsetter.py
@@ -296,11 +296,14 @@ class SubsetResult(NexusResults):
             headers = [
                 'longitude',
                 'latitude',
-                'time',
-                'id'
+                'time'
             ]
             data_variables = list(set([keys for result in results for keys in result['data'].keys()]))
             data_variables.sort()
+
+            if 'id' in list(set([keys for result in results for keys in result.keys()])):
+                headers.append('id')
+
             headers.extend(data_variables)
             for i, result in enumerate(results):
                 cols = []
@@ -308,7 +311,7 @@ class SubsetResult(NexusResults):
                 cols.append(result['longitude'])
                 cols.append(result['latitude'])
                 cols.append(datetime.utcfromtimestamp(result['time']).strftime('%Y-%m-%dT%H:%M:%SZ'))
-                cols.append(result['id'])
+                cols.append(result.get('id'))
 
                 for var in data_variables:
                     cols.append(result['data'].get(var))

--- a/analysis/webservice/algorithms/doms/subsetter.py
+++ b/analysis/webservice/algorithms/doms/subsetter.py
@@ -119,9 +119,6 @@ class DomsResultsRetrievalHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
             matchup_ds_names = []
 
         parameter_s = request.get_argument('parameter', None)
-        if parameter_s is None and len(matchup_ds_names) > 0:
-            raise NexusProcessingException(
-                reason='Parameter must be provided for insitu subset.' % parameter_s, code=400)
 
         try:
             start_time = request.get_start_datetime()
@@ -159,13 +156,6 @@ class DomsResultsRetrievalHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
                 reason='Depth Min should be less than Depth Max', code=400)
 
         platforms = request.get_argument('platforms', None)
-        if platforms is not None:
-            try:
-                p_validation = platforms.split(',')
-                p_validation = [int(p) for p in p_validation]
-                del p_validation
-            except:
-                raise NexusProcessingException(reason='platforms must be a comma-delimited list of integers', code=400)
 
         return primary_ds_name, matchup_ds_names, parameter_s, start_time, end_time, \
                bounding_polygon, depth_min, depth_max, platforms
@@ -318,7 +308,7 @@ class SubsetResult(NexusResults):
                 cols.append(datetime.utcfromtimestamp(result['time']).strftime('%Y-%m-%dT%H:%M:%SZ'))
 
                 for var in data_variables:
-                    cols.append(result['data'][var])
+                    cols.append(result['data'].get(var))
                 if i == 0:
                     rows.append(','.join(headers))
                 rows.append(','.join(map(str, cols)))

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -418,12 +418,10 @@ paths:
         - in: query
           name: parameter
           description: |
-            The parameter of interest. One of 'sst', 'sss', 'wind'
-          required: true
+            The parameter of interest.
           schema:
             type: string
-            enum: ['sst', 'sss', 'wind']
-          example: sss
+          example: sea_surface_salinity
         - in: query
           name: depthMin
           description: |
@@ -448,8 +446,7 @@ paths:
           required: false
           schema:
             type: string
-            default: 1,2,3,4,5,6,7,8,9
-          example: 1,2,3,4,5,6,7,8,9
+          example: 3B,23
         - in: query
           name: output
           description: |


### PR DESCRIPTION
- Removed int requirement from list of platforms
- Made parameter optional
- Updated openapi spec
- Fixed issue in subsetter when multiple platforms are matched. Since this matches with different science variables, it's possible not every science variable will have a value for each row. 

Tested with:

```bash
/cdmssubset?insitu=ICOADS Release 3.0&startTime=2018-10-21T00:00:00Z&endTime=2018-10-22T01:00:00Z&b=-30,15,-45,30&depthMin=0&depthMax=5&platforms=0,16,17,30,41,42&output=ZIP
```

Result looks as expected. [download.zip](https://github.com/apache/incubator-sdap-nexus/files/10136100/download.zip)