### PR TITLE
SwaggerUI updates & Removal of DOMS terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Deletebyquery: Parameter to set the number of rows to fetch from Solr. Speeds up time to gather tiles to delete; especially when there is a lot of them.
-- `NexusHandler`s can support multiple paths. Useful if we want to rename a path without breaking any existing reliance on the old name.
+- SDAP-443: `NexusHandler`s can support multiple paths. Useful if we want to rename a path without breaking any existing reliance on the old name.
 ### Changed
-- Replacing DOMS terminology with CDMS terminology:
-  - Renaming endpoints:
-    - `/domsresults` -> `/cdmsresults`
-    - `/domslist` -> `/cdmslist`
-  - Removed `/domsvalues` from Swagger UI
-- Swagger UI updates:
-  - `platforms` parameter in `/match_spark` is now a multi-select list.
-  - Added note to `/stats` endpoint to note it is limited to satellite datasets
-- Updated `/version` to report analysis and data access component versions
+- SDAP-443:
+  - Replacing DOMS terminology with CDMS terminology:
+    - Renaming endpoints:
+      - `/domsresults` -> `/cdmsresults`
+      - `/domslist` -> `/cdmslist`
+    - Removed `/domsvalues` from Swagger UI
+  - Swagger UI updates:
+    - `platforms` parameter in `/match_spark` is now a multi-select list.
+    - Added note to `/stats` endpoint to note it is limited to satellite datasets
+  - Updated `/version` to report analysis and data access component versions
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Swagger UI updates:
     - `platforms` parameter in `/match_spark` is now a multi-select list.
     - Added note to `/stats` endpoint to note it is limited to satellite datasets
-  - Updated `/version` to report analysis and data access component versions
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Deletebyquery: Parameter to set the number of rows to fetch from Solr. Speeds up time to gather tiles to delete; especially when there is a lot of them.
+- `NexusHandler`s can support multiple paths. Useful if we want to rename a path without breaking any existing reliance on the old name.
 ### Changed
+- Replacing DOMS terminology with CDMS terminology:
+  - Renaming endpoints (adding aliases):
+    - `/domsresults` -> `/cdmsresults`
+    - `/domslist` -> `/cdmslist`
+  - Removed `/domsvalues` from Swagger UI
+- Swagger UI updates:
+  - `platforms` parameter in `/match_spark` is now a multi-select list.
+  - Added note to `/stats` endpoint to note it is limited to satellite datasets
+- Updated `/version` to report analysis and data access component versions
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NexusHandler`s can support multiple paths. Useful if we want to rename a path without breaking any existing reliance on the old name.
 ### Changed
 - Replacing DOMS terminology with CDMS terminology:
-  - Renaming endpoints (adding aliases):
+  - Renaming endpoints:
     - `/domsresults` -> `/cdmsresults`
     - `/domslist` -> `/cdmslist`
   - Removed `/domsvalues` from Swagger UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Deletebyquery: Parameter to set the number of rows to fetch from Solr. Speeds up time to gather tiles to delete; especially when there is a lot of them.
-- SDAP-443: `NexusHandler`s can support multiple paths. Useful if we want to rename a path without breaking any existing reliance on the old name.
 ### Changed
 - SDAP-443:
   - Replacing DOMS terminology with CDMS terminology:

--- a/analysis/webservice/algorithms/doms/DatasetListQuery.py
+++ b/analysis/webservice/algorithms/doms/DatasetListQuery.py
@@ -29,7 +29,7 @@ from webservice.webmodel import cached
 @nexus_handler
 class DomsDatasetListQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     name = "DOMS Dataset Listing"
-    path = "/domslist"
+    path = ["/domslist", "/cdmslist"]
     description = ""
     params = {}
     singleton = True

--- a/analysis/webservice/algorithms/doms/DatasetListQuery.py
+++ b/analysis/webservice/algorithms/doms/DatasetListQuery.py
@@ -29,7 +29,7 @@ from webservice.webmodel import cached
 @nexus_handler
 class DomsDatasetListQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     name = "DOMS Dataset Listing"
-    path = ["/domslist", "/cdmslist"]
+    path = "/cdmslist"
     description = ""
     params = {}
     singleton = True

--- a/analysis/webservice/algorithms/doms/ResultsRetrieval.py
+++ b/analysis/webservice/algorithms/doms/ResultsRetrieval.py
@@ -24,7 +24,7 @@ from webservice.webmodel import NexusProcessingException
 @nexus_handler
 class DomsResultsRetrievalHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     name = "DOMS Resultset Retrieval"
-    path = "/domsresults"
+    path = ["/domsresults", "/cdmsresults"]
     description = ""
     params = {}
     singleton = True

--- a/analysis/webservice/algorithms/doms/ResultsRetrieval.py
+++ b/analysis/webservice/algorithms/doms/ResultsRetrieval.py
@@ -24,7 +24,7 @@ from webservice.webmodel import NexusProcessingException
 @nexus_handler
 class DomsResultsRetrievalHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
     name = "DOMS Resultset Retrieval"
-    path = ["/domsresults", "/cdmsresults"]
+    path = "/cdmsresults"
     description = ""
     params = {}
     singleton = True

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -16,7 +16,7 @@
 openapi: 3.0.3
 info:
   description: The next generation cloud-based science data service platform.
-  version: 0.4.2
+  version: 1.0.0
   title: Science Data Analytics Platform (SDAP)
   license:
     name: Apache 2.0
@@ -118,8 +118,24 @@ paths:
 
           required: true
           schema:
-            type: string
+            type: array
+            items:
+              type: string
+              enum:
+                - 0
+                - 3B
+                - 6A
+                - 16
+                - 17
+                - 23
+                - 30
+                - 31
+                - 41
+                - 42
+                - 46
+                - 48
           example: 30
+          explode: false
         - in: query
           name: depthMin
           description: |
@@ -168,7 +184,7 @@ paths:
           schema:
             type: string
             default: sea_surface_temperature
-          example: sst
+          example: sea_surface_temperature
         - in: query
           name: matchOnce
           description: |
@@ -492,90 +508,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /datainbounds:
-    get:
-      summary: Fetches point values for a given dataset and geographical area
-      operationId: datainbounds
-      tags:
-        - Subsetting
-      parameters:
-        - in: query
-          name: ds
-          description: |
-            The Dataset shortname to use in calculation
-          required: true
-          schema:
-            type: string
-            x-dspopulate:
-             - satellite
-          example: avhrr-l4-glob-v2-daily-ncei-ghrsst-sstblend-avhrr-oi-glob-v020-fv020
-        - in: query
-          name: startTime
-          description: |
-            Starting time in format YYYY-MM-DDTHH:mm:ssZ or seconds
-            since epoch
-          required: true
-          schema:
-            type: string
-            format: date-time
-          example: '2012-09-28T00:00:00Z'
-        - in: query
-          name: endTime
-          description: |
-            Ending time in format YYYY-MM-DDTHH:mm:ssZ or seconds
-            since epoch
-          required: true
-          schema:
-            type: string
-            format: date-time
-          example: '2012-09-28T00:01:00Z'
-        - in: query
-          name: b
-          description: |
-            Minimum (Western) Longitude, Minimum (Southern) Latitude,
-            Maximum (Eastern) Longitude, Maximum (Northern) Latitude
-          required: true
-          schema:
-            type: string
-          example: -45,15,-30,30
-        - in: query
-          name: parameter
-          description: |
-            The parameter of interest. One of 'sst', 'sss', 'wind'
-          required: true
-          schema:
-            type: string
-            enum: ['sst', 'sss', 'wind']
-          example: sst
-        - in: query
-          name: output
-          description: |
-            Output type. Only 'CSV' or 'JSON' is currently supported
-          required: false
-          schema:
-            type: string
-            default: 'JSON'
-            enum: ['CSV', 'JSON']
-          example: JSON
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MatchupResponse'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   /version:
     get:
       summary: List the version of the API
@@ -596,7 +528,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /domslist:
+  /cdmslist:
     get:
       summary: Provides a list of available data sets
       operationId: domslist
@@ -615,116 +547,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /domsvalues:
-    get:
-      summary: |
-        Fetches stats and data values for the selected in situ source
-        and bounding box
-      operationId: domsvalues
-      tags:
-        - Matchup
-      parameters:
-        - in: query
-          name: source
-          description: |
-            The insitu shortname to find stats and data for
-          required: true
-          schema:
-            type: string
-            x-dspopulate:
-              - insitu
-          example: samos
-        - in: query
-          name: startTime
-          description: |
-            Starting time in format YYYY-MM-DDTHH:mm:ssZ or seconds
-            since epoch
-          required: true
-          schema:
-            type: string
-            format: date-time
-          example: '2013-10-21T00:00:00Z'
-        - in: query
-          name: endTime
-          description: |
-            Ending time in format YYYY-MM-DDTHH:mm:ssZ or seconds
-            since epoch
-          required: true
-          schema:
-            type: string
-            format: date-time
-          example: '2013-10-21T01:00:00Z'
-        - in: query
-          name: b
-          description: |
-            Minimum (Western) Longitude, Minimum (Southern) Latitude,
-            Maximum (Eastern) Longitude, Maximum (Northern) Latitude
-          required: true
-          schema:
-            type: string
-          example: -30,15,-45,30
-        - in: query
-          name: tt
-          description: |
-            Tolerance in time (seconds) when comparing two measurements.
-          required: true
-          schema:
-            type: integer
-          example: 86400
-        - in: query
-          name: rt
-          description: |
-            Tolerance in radius (meters) when comparing two
-            measurements.
-          required: true
-          schema:
-            type: number
-          example: 1000.0
-        - in: query
-          name: depthMin
-          description: |
-            Minimum depth of measurements. Must be less than depthMax.
-          required: false
-          schema:
-            type: integer
-          example: 0
-        - in: query
-          name: depthMax
-          description: |
-            Maximum depth of measurements. Must be greater than
-            depthMin.
-          required: false
-          schema:
-            type: integer
-          example: 5
-        - in: query
-          name: platforms
-          description: |
-            Platforms to include for subset consideration.
-          required: false
-          schema:
-            type: string
-          example: 1,2,3,4,5,6,7,8,9
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DomsValues'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '500':
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-  /domsresults:
+  /cdmsresults:
     get:
       summary: |
         Convert matchup result
@@ -780,6 +603,7 @@ paths:
       operationId: stats
       tags:
         - Analytics
+      description: "NOTE: Only supports satellite datasets."
       parameters:
         - in: query
           name: ds

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -91,51 +91,7 @@ paths:
           schema:
             type: string
           example: -45,15,-30,30
-        - in: query
-          name: platforms
-          description: |
-            Platforms to include for matchup consideration. Platform
-            depends on which insitu dataset is selected. Use platform ID
-            in the matchup query.
-
-            <details>
-              <summary>Expand to see a list of valid platforms IDs:</summary>
-            | Platform ID | Platform Name                           | Web Link                                                   |
-            | ----------- | --------------------------------------- | ---------------------------------------------------------- |
-            | 3B          | autonomous surface water vehicle        | [Link](http://vocab.nerc.ac.uk/collection/L06/current/3B/) |
-            | 6A          | glider                                  | [Link](http://vocab.nerc.ac.uk/collection/L06/current/6A/) |
-            | 0           | unknown                                 | [Link](http://vocab.nerc.ac.uk/collection/L06/current/0/)  |
-            | 16          | offshore structure                      | [Link](http://vocab.nerc.ac.uk/collection/L06/current/16/) |
-            | 17          | coastal structure                       | [Link](http://vocab.nerc.ac.uk/collection/L06/current/17/) |
-            | 23          | towed unmanned submersible              | [Link](http://vocab.nerc.ac.uk/collection/L06/current/23/) |
-            | 30          | ship                                    | [Link](http://vocab.nerc.ac.uk/collection/L06/current/30/) |
-            | 31          | research vessel                         | [Link](http://vocab.nerc.ac.uk/collection/L06/current/31/) |
-            | 41          | moored surface buoy                     | [Link](http://vocab.nerc.ac.uk/collection/L06/current/41/) |
-            | 42          | drifting surface float                  | [Link](http://vocab.nerc.ac.uk/collection/L06/current/42/) |
-            | 46          | drifting subsurface profiling float     | [Link](http://vocab.nerc.ac.uk/collection/L06/current/46/) |
-            | 48          | mooring                                 | [Link](http://vocab.nerc.ac.uk/collection/L06/current/48/) |
-            </details>
-
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-              enum:
-                - 0
-                - 3B
-                - 6A
-                - 16
-                - 17
-                - 23
-                - 30
-                - 31
-                - 41
-                - 42
-                - 46
-                - 48
-          example: 30
-          explode: false
+        - $ref: '#/components/parameters/Platforms'
         - in: query
           name: depthMin
           description: |
@@ -470,14 +426,7 @@ paths:
           schema:
             type: integer
           example: 5
-        - in: query
-          name: platforms
-          description: |
-            Platforms to include for subset consideration.
-          required: false
-          schema:
-            type: string
-          example: 3B,23
+        - $ref: '#/components/parameters/Platforms'
         - in: query
           name: output
           description: |
@@ -701,6 +650,53 @@ externalDocs:
   description: Documentation
   url: https://incubator-sdap-nexus.readthedocs.io/en/latest/index.html
 components:
+  parameters:
+    Platforms:
+      in: query
+      name: platforms
+      description: |
+        Platforms to include for matchup consideration. Platform
+        depends on which insitu dataset is selected. Use platform ID
+        in the matchup query.
+        
+        <details>
+          <summary>Expand to see a list of valid platforms IDs:</summary>
+        | Platform ID | Platform Name                           | Web Link                                                   |
+        | ----------- | --------------------------------------- | ---------------------------------------------------------- |
+        | 3B          | autonomous surface water vehicle        | [Link](http://vocab.nerc.ac.uk/collection/L06/current/3B/) |
+        | 6A          | glider                                  | [Link](http://vocab.nerc.ac.uk/collection/L06/current/6A/) |
+        | 0           | unknown                                 | [Link](http://vocab.nerc.ac.uk/collection/L06/current/0/)  |
+        | 16          | offshore structure                      | [Link](http://vocab.nerc.ac.uk/collection/L06/current/16/) |
+        | 17          | coastal structure                       | [Link](http://vocab.nerc.ac.uk/collection/L06/current/17/) |
+        | 23          | towed unmanned submersible              | [Link](http://vocab.nerc.ac.uk/collection/L06/current/23/) |
+        | 30          | ship                                    | [Link](http://vocab.nerc.ac.uk/collection/L06/current/30/) |
+        | 31          | research vessel                         | [Link](http://vocab.nerc.ac.uk/collection/L06/current/31/) |
+        | 41          | moored surface buoy                     | [Link](http://vocab.nerc.ac.uk/collection/L06/current/41/) |
+        | 42          | drifting surface float                  | [Link](http://vocab.nerc.ac.uk/collection/L06/current/42/) |
+        | 46          | drifting subsurface profiling float     | [Link](http://vocab.nerc.ac.uk/collection/L06/current/46/) |
+        | 48          | mooring                                 | [Link](http://vocab.nerc.ac.uk/collection/L06/current/48/) |
+        </details>
+
+      required: true
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - 0
+            - 3B
+            - 6A
+            - 16
+            - 17
+            - 23
+            - 30
+            - 31
+            - 41
+            - 42
+            - 46
+            - 48
+      example: 30
+      explode: false
   schemas:
     DomsQueryResult:
       type: object

--- a/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
+++ b/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
@@ -62,25 +62,13 @@ class NexusAppBuilder:
         )
 
         for clazzWrapper in NexusHandler.AVAILABLE_HANDLERS:
-            path = clazzWrapper.path
-
-            if isinstance(path, list):
-                for p in path:
-                    self.handlers.append(
-                        (
-                            p,
-                            NexusRequestHandler,
-                            handler_args_builder.get_args(clazzWrapper)
-                        )
-                    )
-            else:
-                self.handlers.append(
-                    (
-                        clazzWrapper.path,
-                        NexusRequestHandler,
-                        handler_args_builder.get_args(clazzWrapper)
-                    )
+            self.handlers.append(
+                (
+                    clazzWrapper.path,
+                    NexusRequestHandler,
+                    handler_args_builder.get_args(clazzWrapper)
                 )
+            )
 
         return self
 

--- a/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
+++ b/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
@@ -31,10 +31,7 @@ class NexusAppBuilder:
 
         class VersionHandler(tornado.web.RequestHandler):
             def get(self):
-                analysis_version = pkg_resources.get_distribution("nexusanalysis").version
-                data_access_version = pkg_resources.get_distribution("nexus-data-access").version
-
-                self.write(f'Analysis version: {analysis_version}; Data Access version: {data_access_version}')
+                self.write(pkg_resources.get_distribution("nexusanalysis").version)
 
         self.handlers.append((r"/version", VersionHandler))
 

--- a/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
+++ b/analysis/webservice/nexus_tornado/app_builders/NexusAppBuilder.py
@@ -31,7 +31,10 @@ class NexusAppBuilder:
 
         class VersionHandler(tornado.web.RequestHandler):
             def get(self):
-                self.write(pkg_resources.get_distribution("nexusanalysis").version)
+                analysis_version = pkg_resources.get_distribution("nexusanalysis").version
+                data_access_version = pkg_resources.get_distribution("nexus-data-access").version
+
+                self.write(f'Analysis version: {analysis_version}; Data Access version: {data_access_version}')
 
         self.handlers.append((r"/version", VersionHandler))
 
@@ -62,13 +65,25 @@ class NexusAppBuilder:
         )
 
         for clazzWrapper in NexusHandler.AVAILABLE_HANDLERS:
-            self.handlers.append(
-                (
-                    clazzWrapper.path,
-                    NexusRequestHandler,
-                    handler_args_builder.get_args(clazzWrapper)
+            path = clazzWrapper.path
+
+            if isinstance(path, list):
+                for p in path:
+                    self.handlers.append(
+                        (
+                            p,
+                            NexusRequestHandler,
+                            handler_args_builder.get_args(clazzWrapper)
+                        )
+                    )
+            else:
+                self.handlers.append(
+                    (
+                        clazzWrapper.path,
+                        NexusRequestHandler,
+                        handler_args_builder.get_args(clazzWrapper)
+                    )
                 )
-            )
 
         return self
 


### PR DESCRIPTION
- Updated platform in match_spark to be multi select
- I think SDAP versioning is working with the /version endpoint so I’ll leave that in.
- Removed /domsvalues and /datainbounds endpoint from SwaggerUI
- Added note to /stats entry in SUI to note it is limited to satellite datasets