### PR TITLE
SDAP-434 + SDAP-447 - Fix for webapp image build failure + image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- SDAP-434: Temporary fix for conda install step in docker image build breaking conda
+### Security
+
 ## [1.0.0] - 2022-11-22
 ### Added
 - SDAP-388: Enable SDAP to proxy/redirect to alternate SDAP

--- a/docker/nexus-webapp/Dockerfile
+++ b/docker/nexus-webapp/Dockerfile
@@ -64,7 +64,7 @@ RUN apk --no-cache add wget zlib && \
 COPY docker/nexus-webapp/install_conda.sh ./install_conda.sh
 RUN /tmp/install_conda.sh 
 
-RUN conda install python=3.8
+RUN conda install python=3.8 tqdm
 
 RUN conda install mamba -y -c conda-forge
 

--- a/docker/nexus-webapp/Dockerfile
+++ b/docker/nexus-webapp/Dockerfile
@@ -64,9 +64,8 @@ RUN apk --no-cache add wget zlib && \
 COPY docker/nexus-webapp/install_conda.sh ./install_conda.sh
 RUN /tmp/install_conda.sh 
 
-RUN conda install -c conda-forge python=3.8.15 tqdm
-
-RUN conda install mamba -y -c conda-forge
+RUN conda install -c conda-forge python=3.8.15=h257c98d_0_cpython tqdm=4.64.1=py38h06a4308_0
+RUN conda install -c conda-forge mamba
 
 RUN cd /usr/lib && ln -s libcom_err.so.2 libcom_err.so.3 && \ 
     cd /opt/conda/lib && \

--- a/docker/nexus-webapp/Dockerfile
+++ b/docker/nexus-webapp/Dockerfile
@@ -64,7 +64,7 @@ RUN apk --no-cache add wget zlib && \
 COPY docker/nexus-webapp/install_conda.sh ./install_conda.sh
 RUN /tmp/install_conda.sh 
 
-RUN conda install python=3.8 tqdm
+RUN conda install -c conda-forge python=3.8.15 tqdm
 
 RUN conda install mamba -y -c conda-forge
 

--- a/docker/nexus-webapp/Dockerfile
+++ b/docker/nexus-webapp/Dockerfile
@@ -64,10 +64,9 @@ RUN apk --no-cache add wget zlib && \
 COPY docker/nexus-webapp/install_conda.sh ./install_conda.sh
 RUN /tmp/install_conda.sh 
 
-RUN conda install -c conda-forge python=3.8.15=h257c98d_0_cpython tqdm=4.64.1=py38h06a4308_0
-RUN conda install -c conda-forge mamba
+RUN conda install -c conda-forge python=3.8.15=h257c98d_0_cpython tqdm=4.64.1=py38h06a4308_0  mamba && conda clean -afy
 
-RUN cd /usr/lib && ln -s libcom_err.so.2 libcom_err.so.3 && \ 
+RUN cd /usr/lib && ln -s libcom_err.so.2 libcom_err.so.3 && \
     cd /opt/conda/lib && \
     ln -s libnetcdf.so.11 libnetcdf.so.7 && \
     ln -s libkea.so.1.4.6 libkea.so.1.4.5 && \
@@ -89,10 +88,10 @@ COPY analysis /incubator-sdap-nexus/analysis
 COPY tools /incubator-sdap-nexus/tools
 
 WORKDIR /incubator-sdap-nexus/data-access
-RUN python3 setup.py install
+RUN python3 setup.py install clean
 
 WORKDIR /incubator-sdap-nexus/analysis
-RUN python3 setup.py install
+RUN python3 setup.py install clean && mamba clean -afy
 
 
 WORKDIR /incubator-sdap-nexus/tools/deletebyquery

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -128,12 +128,6 @@ Now we can build the webapp with:
 
   docker build . -f docker/nexus-webapp/Dockerfile -t sdap-local/sdap-nexus-webapp:${NEXUS_VERSION}
 
-.. note::
-
-  The build may fail with a message like ``ModuleNotFoundError: No module named 'tqdm'``, this is an issue `we're aware of <https://issues.apache.org/jira/projects/SDAP/issues/SDAP-434>`_.
-  The issue can be fixed by editing the file ``${NEXUS_DIR}/docker/nexus-webapp/Dockerfile``.
-  Change the line ``RUN conda install python=3.8`` (line 67) to ``RUN conda install python=3.8 tqdm`` and the build should succeed (maybe also include the flag ``--no-cache`` in the ``docker build`` command when retrying the build).
-
 Verify Successful Build
 ====
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -130,7 +130,7 @@ Now we can build the webapp with:
 
 .. note::
 
-  The build may fail with a message like ``ModuleNotFoundError: No module named 'tqdm'``, this is and issue `we're aware of <https://issues.apache.org/jira/projects/SDAP/issues/SDAP-434>`_.
+  The build may fail with a message like ``ModuleNotFoundError: No module named 'tqdm'``, this is an issue `we're aware of <https://issues.apache.org/jira/projects/SDAP/issues/SDAP-434>`_.
   The issue can be fixed by editing the file ``${NEXUS_DIR}/docker/nexus-webapp/Dockerfile``.
   Change the line ``RUN conda install python=3.8`` (line 67) to ``RUN conda install python=3.8 tqdm`` and the build should succeed (maybe also include the flag ``--no-cache`` in the ``docker build`` command when retrying the build).
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -128,6 +128,12 @@ Now we can build the webapp with:
 
   docker build . -f docker/nexus-webapp/Dockerfile -t sdap-local/sdap-nexus-webapp:${NEXUS_VERSION}
 
+.. note::
+
+  The build may fail with a message like ``ModuleNotFoundError: No module named 'tqdm'``, this is and issue `we're aware of <https://issues.apache.org/jira/projects/SDAP/issues/SDAP-434>`_.
+  The issue can be fixed by editing the file ``${NEXUS_DIR}/docker/nexus-webapp/Dockerfile``.
+  Change the line ``RUN conda install python=3.8`` (line 67) to ``RUN conda install python=3.8 tqdm`` and the build should succeed (maybe also include the flag ``--no-cache`` in the ``docker build`` command when retrying the build).
+
 Verify Successful Build
 ====
 


### PR DESCRIPTION
Failure seemed to trace back to the python=3.8 install step in the dockerfile, so I restricted the package specifier to install the exact version + build found in a webapp image built prior to this issue. Tested successfully with `--no-cache`.