### PR TITLE
SDAP-444 - Fixed resultSizeLimit truncating result storage in match_spark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `platforms` param optional in `/cdmssubset`, and removed int requirement
 - Updated OpenAPI specification for `/cdmssubset` to accurately reflect `platforms` and `parameter` field options.
 - SDAP-436: Added special case for handling Cassandra SwathMulti tiles with uniform time arrays
+- SDAP-444: Fixed `resultSizeLimit` param in `/match_spark` truncating the results that are stored for the results endpoint.
 ### Security
 
 ## [1.0.0] - 2022-12-05

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -292,9 +292,11 @@ class Matchup(NexusCalcSparkHandler):
         # Get only the first "result_size_limit" results
         # '0' means returns everything
         if result_size_limit > 0:
-            matches = matches[0:result_size_limit]
+            return_matches = matches[0:result_size_limit]
+        else:
+            return_matches = matches
 
-        result = DomsQueryResults(results=matches, args=args,
+        result = DomsQueryResults(results=return_matches, args=args,
                                   details=details, bounds=None,
                                   count=len(matches), computeOptions=None,
                                   executionId=execution_id)


### PR DESCRIPTION
To my understanding, resultSizeLimit should only limit the results that are returned to the user for the match_spark query, but it can also truncate the results that are stored to be fetched by the results endpoint.