### PR TITLE
SDAP-459 - Ensure min/max lat/lon values are float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-412: Explicit definition of `__eq__` and `__hash__` in matchup `DomsPoint` class. This ensures all primary-secondary pairs with the same primary point are merged in the `combineByKey` step.
 - SDAP-438: Replace variable value NaN with None to fix error in result storage
 - SDAP-444: Fixed `resultSizeLimit` param in `/match_spark` truncating the results that are stored for the results endpoint.
-- SDAP-459: Ensure min/max lat/lon values are float
 ### Security
 
 ## [1.0.0] - 2022-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-412: Explicit definition of `__eq__` and `__hash__` in matchup `DomsPoint` class. This ensures all primary-secondary pairs with the same primary point are merged in the `combineByKey` step.
 - SDAP-438: Replace variable value NaN with None to fix error in result storage
 - SDAP-444: Fixed `resultSizeLimit` param in `/match_spark` truncating the results that are stored for the results endpoint.
+- SDAP-459: Ensure min/max lat/lon values are float
 ### Security
 
 ## [1.0.0] - 2022-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deletebyquery: Parameter to set the number of rows to fetch from Solr. Speeds up time to gather tiles to delete; especially when there is a lot of them.
 - Added Saildrone's `baja_2018` insitu dataset.
 - SDAP-454: Added new query parameter `prioritizeDistance` to matchup algorithm
+- SDAP-459: Added explicit definitions of min/max lat/lon values in nexustiles Solr collection creation script
 ### Changed
 - SDAP-443:
   - Replacing DOMS terminology with CDMS terminology:

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -500,13 +500,7 @@ class NexusTileService(object):
                 if isinstance(max_lon, list):
                     max_lon = max_lon[0]
 
-                # In case it's been stored as a string
-                # Observed in JPL CDMS SDAP deployment
-                tile.bbox = BBox(
-                    float(min_lat), 
-                    float(max_lat), 
-                    float(min_lon), 
-                    float(max_lon))
+                tile.bbox = BBox(min_lat, max_lat, min_lon, max_lon)
             except KeyError:
                 pass
 

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -500,7 +500,13 @@ class NexusTileService(object):
                 if isinstance(max_lon, list):
                     max_lon = max_lon[0]
 
-                tile.bbox = BBox(min_lat, max_lat, min_lon, max_lon)
+                # In case it's been stored as a string
+                # Observed in JPL CDMS SDAP deployment
+                tile.bbox = BBox(
+                    float(min_lat), 
+                    float(max_lat), 
+                    float(min_lon), 
+                    float(max_lon))
             except KeyError:
                 pass
 

--- a/docker/solr/cloud-init/create-collection.py
+++ b/docker/solr/cloud-init/create-collection.py
@@ -125,16 +125,23 @@ try:
             else:
                 logging.error("Error creating field type 'geo': {}".format(field_type_response.text))
 
-            field_payload = json.dumps({
-                "add-field": {
-                    "name": "geo",
-                    "type": "geo"}})
-            logging.info("Creating field 'geo'...")
-            field_response = requests.post(url=schema_api, data=field_payload)
-            if field_response.status_code < 400:
-                logging.info("Success.")
-            else:
-                logging.error("Error creating field 'geo': {}".format(field_response.text))
+            def add_field(schema_api, name, type):
+                field_payload = json.dumps({
+                    "add-field": {
+                        "name": name,
+                        "type": type}})
+                logging.info(f"Creating {type} field '{name}'...")
+                field_response = requests.post(url=schema_api, data=field_payload)
+                if field_response.status_code < 400:
+                    logging.info("Success.")
+                else:
+                    logging.error(f"Error creating field '{name}': {field_response.text}")
+
+            add_field(schema_api, 'geo', 'geo')
+            add_field(schema_api, 'tile_max_lat', 'pdouble')
+            add_field(schema_api, 'tile_min_lat', 'pdouble')
+            add_field(schema_api, 'tile_max_lon', 'pdouble')
+            add_field(schema_api, 'tile_min_lon', 'pdouble')
 
 finally:
     zk.stop()


### PR DESCRIPTION
We observed Solr storing the lat/lon values as strings instead of double/doubles. This was a very abnormal situation, but we should still handle this to avoid having to reindex data should this happen again