### PR TITLE
Readthedocs build failure fix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+version: 2
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-copybutton


### PR DESCRIPTION
In 1.1.0 release, we tried to add copy buttons to the code blocks for the SDAP docs. 

Turns out this was done incompletely and we need to direct RTD to install the relevant Sphinx extension so we can get our builds running successfully.