### PR TITLE
Updated matchup output filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Improved speed of results insert
     - Updated `id` field of insitu points to include depth. This solves an issue with NetCDF result rendering where different insitu observations at the same place & time but at different depths were being excluded for having the same `id`.
 - SDAP-466: Matchup now defines secondary `platform` fields with `platform.id` if it is available and not blank. It then uses `platform.code` and `platform.type` as fallbacks, then just the value of `platform` if none work.
+- SDAP-468: Updated matchup output filename
 ### Deprecated
 ### Removed
 ### Fixed

--- a/analysis/webservice/algorithms/doms/BaseDomsHandler.py
+++ b/analysis/webservice/algorithms/doms/BaseDomsHandler.py
@@ -106,6 +106,9 @@ class DomsQueryResults(NexusResults):
     def toNetCDF(self):
         return DomsNetCDFFormatter.create(self.__executionId, self.results(), self.__args, self.__details)
 
+    def filename(self):
+        return f'CDMS_{self.__executionId}'
+
 
 class DomsCSVFormatter:
     @staticmethod

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -535,6 +535,16 @@ paths:
             type: string
             enum: ['CSV', 'NETCDF', 'JSON']
           example: CSV
+        - in: query
+          name: filename
+          description: |
+            Name of output file. Only works with CSV and NETCDF 
+            output types. Do not include file extension in this field. 
+            If this value is not provided, the filename will be 
+            `CDMS_[execution_id].[csv|nc]`
+          required: false
+          schema:
+            type: string
       responses:
         '200':
           description: Successful operation

--- a/analysis/webservice/nexus_tornado/request/renderers/NexusCSVRenderer.py
+++ b/analysis/webservice/nexus_tornado/request/renderers/NexusCSVRenderer.py
@@ -23,8 +23,13 @@ class NexusCSVRenderer(object):
         self._request = nexus_request
 
     def render(self, tornado_handler, result):
+        filename = self._request.get_argument('filename')
+        if filename is None:
+            filename = result.filename()
+        filename = f'{filename}.csv'
+
         tornado_handler.set_header("Content-Type", "text/csv")
-        tornado_handler.set_header("Content-Disposition", "filename=\"%s\"" % self._request.get_argument('filename', "download.csv"))
+        tornado_handler.set_header("Content-Disposition", f"filename=\"{filename}\"")
         try:
             tornado_handler.write(result.toCSV())
             tornado_handler.finish()

--- a/analysis/webservice/nexus_tornado/request/renderers/NexusNETCDFRenderer.py
+++ b/analysis/webservice/nexus_tornado/request/renderers/NexusNETCDFRenderer.py
@@ -23,8 +23,13 @@ class NexusNETCDFRenderer(object):
         self._request = nexus_request
 
     def render(self, tornado_handler, result):
+        filename = self._request.get_argument('filename')
+        if filename is None:
+            filename = result.filename()
+        filename = f'{filename}.nc'
+
         tornado_handler.set_header("Content-Type", "application/x-netcdf")
-        tornado_handler.set_header("Content-Disposition", "attachment; filename=\"%s\"" % self._request.get_argument('filename', "download.nc"))
+        tornado_handler.set_header("Content-Disposition", f"attachment; filename=\"{filename}\"")
         try:
             tornado_handler.write(result.toNetCDF())
         except:

--- a/analysis/webservice/webmodel/NexusResults.py
+++ b/analysis/webservice/webmodel/NexusResults.py
@@ -107,6 +107,10 @@ class NexusResults:
                 self.__meta = self.__meta  # Risky
             self._extendMeta(self.__meta, minLat, maxLat, minLon, maxLon, ds, startTime, endTime)
 
+    @staticmethod
+    def filename(self):
+        return 'download'
+
     def toJson(self):
         data = {
             'meta': self.__meta,


### PR DESCRIPTION
Matchup output is now written to CDMS_[execution_ID].[csv|nc]. 

Tested locally, the file downloaded was correctly named. 

---

**Note:** There is an existing feature where a `filename` param provided will be used as the output filename. This change does not impact that behavior. If a `filename` param is provided, it will still be used as the output filename. If not, CDMS_[execution_ID].[csv|nc] will be used for the matchup result endpoints. This might be what Shawn was thinking of in terms of doms renaming output files. 

Also added the missing `filename` param to the `/cdmsresults` openapi definition. 