### PR TITLE
Fix for cdmslist bug in pagination PR

### DIFF
--- a/analysis/webservice/algorithms/doms/DatasetListQuery.py
+++ b/analysis/webservice/algorithms/doms/DatasetListQuery.py
@@ -120,4 +120,14 @@ class DomsDatasetListQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
             "insitu": insituList
         }
 
-        return NexusResults(results=values)
+        return DatasetListResults(results=values)
+
+
+class DatasetListResults(NexusResults):
+    def __init__(self, results=None):
+        NexusResults.__init__(self, results=results)
+
+        self.__results = results
+
+    def toJson(self):
+        return json.dumps({'data': self.__results}, indent=4)

--- a/analysis/webservice/algorithms/doms/DatasetListQuery.py
+++ b/analysis/webservice/algorithms/doms/DatasetListQuery.py
@@ -23,7 +23,7 @@ from . import config
 from . import values
 from webservice.algorithms.NexusCalcHandler import NexusCalcHandler as BaseHandler
 from webservice.NexusHandler import nexus_handler
-from webservice.webmodel import cached
+from webservice.webmodel import cached, NexusResults
 
 
 @nexus_handler
@@ -120,4 +120,4 @@ class DomsDatasetListQueryHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
             "insitu": insituList
         }
 
-        return BaseDomsHandler.DomsQueryResults(results=values)
+        return NexusResults(results=values)


### PR DESCRIPTION
Fixes a bug in #261 which causes the `/cdmslist` endpoint to break. Bug was due to the endpoint producing a `DomsQueryResults` object. The pagination PR makes an assumption that one of the fields of this object will be given as non-null, which doesn't apply to the result data for this endpoint. This PR provides the endpoint with its own result type, which should remove all the unused/empty/misleading fields that come with using `DomsQueryResults` or even the base `NexusResults` class.
The changes in this PR will also allow for the closure of #177, as the issue handled by it will no longer exist.