### PR TITLE
SDAP-479: Fix cdmssubset failing if standard/variable name not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-465: Removed `climatology` directory. 
 ### Fixed
 - SDAP-474: Fixed bug in CSV attributes where secondary dataset would be rendered as comma separated characters
+- SDAP-479: Fixed `/cdmssubset` failure for variables without specified standard_name. 
 ### Security
 
 ## [1.1.0] - 2023-04-26

--- a/analysis/webservice/algorithms/doms/subsetter.py
+++ b/analysis/webservice/algorithms/doms/subsetter.py
@@ -203,14 +203,22 @@ class DomsResultsRetrievalHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
 
             tile = tile[0]
 
+            def get_best_name(variable):
+                if variable.standard_name:
+                    return variable.standard_name
+                elif variable.variable_name:
+                    return variable.variable_name
+                else:
+                    return 'UNNAMED_VARIABLE'
+
             for nexus_point in tile.nexus_point_generator():
                 if tile.is_multi:
                     data_points = {
-                        tile.variables[idx].standard_name: nexus_point.data_vals[idx]
+                        get_best_name(tile.variables[idx]): nexus_point.data_vals[idx]
                         for idx in range(len(tile.variables))
                     }
                 else:
-                    data_points = {tile.variables[0].standard_name: nexus_point.data_vals}
+                    data_points = {get_best_name(tile.variables[0]): nexus_point.data_vals}
                 data.append({
                     'latitude': nexus_point.latitude,
                     'longitude': nexus_point.longitude,

--- a/analysis/webservice/algorithms/doms/subsetter.py
+++ b/analysis/webservice/algorithms/doms/subsetter.py
@@ -209,7 +209,10 @@ class DomsResultsRetrievalHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
                 elif variable.variable_name:
                     return variable.variable_name
                 else:
-                    return 'UNNAMED_VARIABLE'
+                    raise NexusProcessingException(
+                        reason=f'Variable in subsetted data does not have defined name',
+                        code=500
+                    )
 
             for nexus_point in tile.nexus_point_generator():
                 if tile.is_multi:


### PR DESCRIPTION
When generating CSV headers for variables, it would be assumed that `standard_name` would be defined. That would not always be the case, and this would cause an error. This PR uses `variable_name` as a fallback so datasets without defined standard names can be subsetted.