### PR TITLE
SDAP-39 - Querying tiles by polygon now uses bbox query where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-474: Fixed bug in CSV attributes where secondary dataset would be rendered as comma separated characters
 - SDAP-475: Bug fixes for `/timeSeriesSpark` and `/timeAvgMapSpark`
 - SDAP-479: Fixed `/cdmssubset` failure for variables without specified standard_name. 
+- SDAP-39: When querying for tiles by polygon, use the poly's bounding box with the bbox methods instead of using Solr's polygon search
 - Status code for results endpoint if execution id is not found fixed to be `404` instead of `500`.
 ### Security
 

--- a/data-access/nexustiles/dao/SolrProxy.py
+++ b/data-access/nexustiles/dao/SolrProxy.py
@@ -230,9 +230,16 @@ class SolrProxy(object):
 
         search = 'dataset_s:%s' % ds
 
+        bounds = bounding_polygon.bounds
+
+        min_lon = bounds[0]
+        min_lat = bounds[1]
+        max_lon = bounds[2]
+        max_lat = bounds[3]
+
         params = {
             'fq': [
-                "{!field f=geo}Intersects(%s)" % bounding_polygon.wkt,
+                "geo:[%s,%s TO %s,%s]" % (min_lat, min_lon, max_lat, max_lon),
                 "tile_count_i:[1 TO *]",
                 "day_of_year_i:[* TO %s]" % day_of_year
             ],
@@ -312,9 +319,11 @@ class SolrProxy(object):
 
         search = 'dataset_s:%s' % ds
 
+        min_lon, min_lat, max_lon, max_lat = bounding_polygon.bounds
+
         additionalparams = {
             'fq': [
-                "{!field f=geo}Intersects(%s)" % bounding_polygon.wkt,
+                "geo:[%s,%s TO %s,%s]" % (min_lat, min_lon, max_lat, max_lon),
                 "tile_count_i:[1 TO *]"
             ]
         }
@@ -344,9 +353,11 @@ class SolrProxy(object):
 
         search = 'dataset_s:%s' % ds
 
+        min_lon, min_lat, max_lon, max_lat = bounding_polygon.bounds
+
         additionalparams = {
             'fq': [
-                "{!field f=geo}Intersects(%s)" % bounding_polygon.wkt,
+                "geo:[%s,%s TO %s,%s]" % (min_lat, min_lon, max_lat, max_lon),
                 "tile_count_i:[1 TO *]"
             ]
         }
@@ -376,9 +387,11 @@ class SolrProxy(object):
 
         search = 'dataset_s:%s' % ds
 
+        min_lon, min_lat, max_lon, max_lat = bounding_polygon.bounds
+
         additionalparams = {
             'fq': [
-                "{!field f=geo}Intersects(%s)" % bounding_polygon.wkt,
+                "geo:[%s,%s TO %s,%s]" % (min_lat, min_lon, max_lat, max_lon),
                 "tile_count_i:[1 TO *]"
             ],
             'rows': 0,
@@ -480,9 +493,11 @@ class SolrProxy(object):
                           the_time, the_time
                       )
 
+        min_lon, min_lat, max_lon, max_lat = bounding_polygon.bounds
+
         additionalparams = {
             'fq': [
-                "{!field f=geo}Intersects(%s)" % bounding_polygon.wkt,
+                "geo:[%s,%s TO %s,%s]" % (min_lat, min_lon, max_lat, max_lon),
                 "tile_count_i:[1 TO *]",
                 time_clause
             ]

--- a/data-access/nexustiles/dao/SolrProxy.py
+++ b/data-access/nexustiles/dao/SolrProxy.py
@@ -230,8 +230,6 @@ class SolrProxy(object):
 
         search = 'dataset_s:%s' % ds
 
-        bounds = bounding_polygon.bounds
-
         min_lon, min_lat, max_lon, max_lat = bounding_polygon.bounds
 
         params = {

--- a/data-access/nexustiles/dao/SolrProxy.py
+++ b/data-access/nexustiles/dao/SolrProxy.py
@@ -232,10 +232,7 @@ class SolrProxy(object):
 
         bounds = bounding_polygon.bounds
 
-        min_lon = bounds[0]
-        min_lat = bounds[1]
-        max_lon = bounds[2]
-        max_lat = bounds[3]
+        min_lon, min_lat, max_lon, max_lat = bounding_polygon.bounds
 
         params = {
             'fq': [

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -179,8 +179,16 @@ class NexusTileService(object):
 
     @tile_data()
     def find_all_tiles_in_polygon_at_time(self, bounding_polygon, dataset, time, **kwargs):
-        return self._metadatastore.find_all_tiles_in_polygon_at_time(bounding_polygon, dataset, time, rows=5000,
-                                                                     **kwargs)
+        bounds = bounding_polygon.bounds
+
+        min_lon = bounds[0]
+        min_lat = bounds[1]
+        max_lon = bounds[2]
+        max_lat = bounds[3]
+
+        return self.find_all_tiles_in_box_at_time(min_lat, max_lat, min_lon, max_lon, dataset, time, **kwargs)
+        # return self._metadatastore.find_all_tiles_in_polygon_at_time(bounding_polygon, dataset, time, rows=5000,
+        #                                                              **kwargs)
 
     @tile_data()
     def find_tiles_in_box(self, min_lat, max_lat, min_lon, max_lon, ds=None, start_time=0, end_time=-1, **kwargs):
@@ -195,13 +203,23 @@ class NexusTileService(object):
     @tile_data()
     def find_tiles_in_polygon(self, bounding_polygon, ds=None, start_time=0, end_time=-1, **kwargs):
         # Find tiles that fall within the polygon in the Solr index
-        if 'sort' in list(kwargs.keys()):
-            tiles = self._metadatastore.find_all_tiles_in_polygon(bounding_polygon, ds, start_time, end_time, **kwargs)
-        else:
-            tiles = self._metadatastore.find_all_tiles_in_polygon_sorttimeasc(bounding_polygon, ds, start_time,
-                                                                              end_time,
-                                                                              **kwargs)
-        return tiles
+
+        bounds = bounding_polygon.bounds
+
+        min_lon = bounds[0]
+        min_lat = bounds[1]
+        max_lon = bounds[2]
+        max_lat = bounds[3]
+
+        return self.find_tiles_in_box(min_lat, max_lat, min_lon, max_lon, ds, start_time, end_time, **kwargs)
+
+        # if 'sort' in list(kwargs.keys()):
+        #     tiles = self._metadatastore.find_all_tiles_in_polygon(bounding_polygon, ds, start_time, end_time, **kwargs)
+        # else:
+        #     tiles = self._metadatastore.find_all_tiles_in_polygon_sorttimeasc(bounding_polygon, ds, start_time,
+        #                                                                       end_time,
+        #                                                                       **kwargs)
+        # return tiles
 
     @tile_data()
     def find_tiles_by_metadata(self, metadata, ds=None, start_time=0, end_time=-1, **kwargs):

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -179,16 +179,8 @@ class NexusTileService(object):
 
     @tile_data()
     def find_all_tiles_in_polygon_at_time(self, bounding_polygon, dataset, time, **kwargs):
-        bounds = bounding_polygon.bounds
-
-        min_lon = bounds[0]
-        min_lat = bounds[1]
-        max_lon = bounds[2]
-        max_lat = bounds[3]
-
-        return self.find_all_tiles_in_box_at_time(min_lat, max_lat, min_lon, max_lon, dataset, time, **kwargs)
-        # return self._metadatastore.find_all_tiles_in_polygon_at_time(bounding_polygon, dataset, time, rows=5000,
-        #                                                              **kwargs)
+        return self._metadatastore.find_all_tiles_in_polygon_at_time(bounding_polygon, dataset, time, rows=5000,
+                                                                     **kwargs)
 
     @tile_data()
     def find_tiles_in_box(self, min_lat, max_lat, min_lon, max_lon, ds=None, start_time=0, end_time=-1, **kwargs):
@@ -203,23 +195,13 @@ class NexusTileService(object):
     @tile_data()
     def find_tiles_in_polygon(self, bounding_polygon, ds=None, start_time=0, end_time=-1, **kwargs):
         # Find tiles that fall within the polygon in the Solr index
-
-        bounds = bounding_polygon.bounds
-
-        min_lon = bounds[0]
-        min_lat = bounds[1]
-        max_lon = bounds[2]
-        max_lat = bounds[3]
-
-        return self.find_tiles_in_box(min_lat, max_lat, min_lon, max_lon, ds, start_time, end_time, **kwargs)
-
-        # if 'sort' in list(kwargs.keys()):
-        #     tiles = self._metadatastore.find_all_tiles_in_polygon(bounding_polygon, ds, start_time, end_time, **kwargs)
-        # else:
-        #     tiles = self._metadatastore.find_all_tiles_in_polygon_sorttimeasc(bounding_polygon, ds, start_time,
-        #                                                                       end_time,
-        #                                                                       **kwargs)
-        # return tiles
+        if 'sort' in list(kwargs.keys()):
+            tiles = self._metadatastore.find_all_tiles_in_polygon(bounding_polygon, ds, start_time, end_time, **kwargs)
+        else:
+            tiles = self._metadatastore.find_all_tiles_in_polygon_sorttimeasc(bounding_polygon, ds, start_time,
+                                                                              end_time,
+                                                                              **kwargs)
+        return tiles
 
     @tile_data()
     def find_tiles_by_metadata(self, metadata, ds=None, start_time=0, end_time=-1, **kwargs):


### PR DESCRIPTION
We've been getting issues with Solr's polygon intersection search for certain tile shapes & bounding polys, so let's just use the more reliable bounding box search and mask out the extras. 