### PR TITLE
Bring next release candidate up to date w/ master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-39: When querying for tiles by polygon, use the poly's bounding box with the bbox methods instead of using Solr's polygon search
 - Status code for results endpoint if execution id is not found fixed to be `404` instead of `500`.
 - Ensured links in the `/job` endpoint are https
+- SDAP-488: Workaround to build issue on Apple Silicon (M1/M2). Image build installs nexusproto through PyPI instead of building from source. A build arg `BUILD_NEXUSPROTO` was defined to allow building from source if desired
 ### Security
 
 ## [1.1.0] - 2023-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-479: Fixed `/cdmssubset` failure for variables without specified standard_name. 
 - SDAP-39: When querying for tiles by polygon, use the poly's bounding box with the bbox methods instead of using Solr's polygon search
 - Status code for results endpoint if execution id is not found fixed to be `404` instead of `500`.
+- Ensured links in the `/job` endpoint are https
 ### Security
 
 ## [1.1.0] - 2023-04-26

--- a/analysis/webservice/algorithms/doms/ExecutionStatus.py
+++ b/analysis/webservice/algorithms/doms/ExecutionStatus.py
@@ -54,7 +54,7 @@ class ExecutionStatusHandler(BaseDomsHandler.BaseDomsQueryCalcHandler):
                 )
 
         job_status = NexusExecutionResults.ExecutionStatus(execution_details['status'])
-        host = f'{request.requestHandler.request.protocol}://{request.requestHandler.request.host}'
+        host = f'https://{request.requestHandler.request.host}'
 
         return NexusExecutionResults.NexusExecutionResults(
             status=job_status,

--- a/docker/nexus-webapp/Dockerfile
+++ b/docker/nexus-webapp/Dockerfile
@@ -76,6 +76,8 @@ RUN cd /usr/lib && ln -s libcom_err.so.2 libcom_err.so.3 && \
 # Change REBUILD_CODE if you want tell Docker not to use cached layers from this line on
 ARG REBUILD_CODE=0
 
+ARG BUILD_NEXUSPROTO
+
 ARG APACHE_NEXUSPROTO=https://github.com/apache/incubator-sdap-nexusproto.git
 ARG APACHE_NEXUSPROTO_BRANCH=master
 

--- a/docker/nexus-webapp/install_nexusproto.sh
+++ b/docker/nexus-webapp/install_nexusproto.sh
@@ -13,23 +13,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -e
 
-APACHE_NEXUSPROTO="https://github.com/apache/incubator-sdap-nexusproto.git"
-MASTER="master"
+if [ ! -z ${BUILD_NEXUSPROTO+x} ]; then
+  echo 'Building nexusproto from source...'
 
-GIT_REPO=${1:-$APACHE_NEXUSPROTO}
-GIT_BRANCH=${2:-$MASTER}
+  APACHE_NEXUSPROTO="https://github.com/apache/incubator-sdap-nexusproto.git"
+  MASTER="master"
 
-mkdir nexusproto
-pushd nexusproto
-git init
-git pull ${GIT_REPO} ${GIT_BRANCH}
+  GIT_REPO=${1:-$APACHE_NEXUSPROTO}
+  GIT_BRANCH=${2:-$MASTER}
 
-./gradlew pythonInstall --info
+  mkdir nexusproto
+  pushd nexusproto
+  git init
+  git pull ${GIT_REPO} ${GIT_BRANCH}
 
-./gradlew install --info
+  ./gradlew pythonInstall --info
 
-rm -rf /root/.gradle
-popd
-rm -rf nexusproto
+  ./gradlew install --info
+
+  rm -rf /root/.gradle
+  popd
+  rm -rf nexusproto
+else
+  pip install nexusproto
+fi

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -89,6 +89,16 @@ From the ingester root directory, run:
 
   docker build . -f granule_ingester/docker/Dockerfile -t sdap-local/sdap-granule-ingester:${INGESTER_VERSION}
 
+.. note::
+
+  The granule ingester installs `nexusproto <https://github.com/apache/incubator-sdap-nexusproto>`_ as part of its build process. By default, it installs from `PyPI <https://pypi.org/project/nexusproto/>`_.
+
+  It is possible to build and install directly from source by defining ``--build-arg BUILD_NEXUSPROTO=...`` in the command line.
+  (The value you set is irrelevant; it just needs to be set). You can further define the source repository and branch to build from by
+  defining ``--build-arg APACHE_NEXUSPROTO=...`` and ``--build-arg APACHE_NEXUSPROTO_BRANCH=...``
+
+  Note: Building does not currently work on Apple Silicon (M1/M2). (`SDAP-488 <https://issues.apache.org/jira/browse/SDAP-488>`_)
+
 Build the Solr & Webapp Components
 ======
 
@@ -136,6 +146,16 @@ Now we can build the webapp with:
 .. code-block:: bash
 
   docker build . -f docker/nexus-webapp/Dockerfile -t sdap-local/sdap-nexus-webapp:${NEXUS_VERSION}
+
+.. note::
+
+  The webapp installs `nexusproto <https://github.com/apache/incubator-sdap-nexusproto>`_ as part of its build process. By default, it installs from `PyPI <https://pypi.org/project/nexusproto/>`_.
+
+  It is possible to build and install directly from source by defining ``--build-arg BUILD_NEXUSPROTO=...`` in the command line.
+  (The value you set is irrelevant; it just needs to be set). You can further define the source repository and branch to build from by
+  defining ``--build-arg APACHE_NEXUSPROTO=...`` and ``--build-arg APACHE_NEXUSPROTO_BRANCH=...``
+
+  Note: Building does not currently work on Apple Silicon (M1/M2). (`SDAP-488 <https://issues.apache.org/jira/browse/SDAP-488>`_)
 
 Verify Successful Build
 ====


### PR DESCRIPTION
- Ensured links in the `/job` endpoint are https
- SDAP-488: Workaround to build issue on Apple Silicon (M1/M2). Image build installs nexusproto through PyPI instead of building from source. A build arg `BUILD_NEXUSPROTO` was defined to allow building from source if desired