### PR TITLE
SDAP-505: Support DOMS insitu API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDAP-506:
   - Added STAC Catalog endpoint for matchup outputs
 - SDAP-508: Added spatial extents to the satellite dataset entries in `/list` and `/cdmslist`
+- SDAP-505: Added support for DOMS insitu api 
 ### Changed
 - SDAP-493: 
   - Updated /job endpoint to use `executionId` terminology for consistency with existing `/cdmsresults` endpoint

--- a/analysis/webservice/algorithms/doms/config.py
+++ b/analysis/webservice/algorithms/doms/config.py
@@ -14,36 +14,26 @@
 # limitations under the License.
 
 INSITU_API_ENDPOINT = 'https://doms.jpl.nasa.gov/insitu/1.0/query_data_doms_custom_pagination'
-INSITU_API_SCHEMA_ENDPOINT = 'https://doms.jpl.nasa.gov/insitu/1.0/cdms_schema'
+INSITU_API_SCHEMA_ENDPOINT = None
 
 INSITU_PROVIDER_MAP = [
     {
-        'name': 'NCAR',
-        'endpoint': 'https://cdms.ucar.edu/insitu/1.0/query_data_doms_custom_pagination',
-        'projects': [
-            {
-                'short_name': 'ICOADS_NCAR',
-                'name': 'ICOADS Release 3.0',
-                'platforms': ['0', '16', '17', '30', '41', '42']
-            }
-        ]
-    },
-    {
-        'name': 'NCAR',
-        'projects': [
-            {
-                'short_name': 'ICOADS_JPL',
-                'name': 'ICOADS Release 3.0',
-                'platforms': ['0', '16', '17', '30', '41', '42']
-            }
-        ]
-    },
-    {
         'name': 'Florida State University, COAPS',
+        'endpoint': 'https://doms.coaps.fsu.edu/ws/search/samos_cdms',
         'projects': [
             {
                 'name': 'SAMOS',
                 'platforms': ['30']
+            }
+        ]
+    },
+    {
+        'name': 'NCAR',
+        'endpoint': 'http://rda-work.ucar.edu:8890/ws/search/icoads',
+        'projects': [
+            {
+                'name': 'ICOADS Release 3.0',
+                'platforms': ['0', '16', '17', '30', '41', '42']
             }
         ]
     },

--- a/analysis/webservice/algorithms/doms/config.py
+++ b/analysis/webservice/algorithms/doms/config.py
@@ -29,7 +29,7 @@ INSITU_PROVIDER_MAP = [
     },
     {
         'name': 'NCAR',
-        'endpoint': 'http://rda-work.ucar.edu:8890/ws/search/icoads',
+        'endpoint': 'https://rda-work.ucar.edu/ws/search/icoads',
         'projects': [
             {
                 'name': 'ICOADS Release 3.0',

--- a/analysis/webservice/algorithms/doms/config.py
+++ b/analysis/webservice/algorithms/doms/config.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 INSITU_API_ENDPOINT = 'https://doms.jpl.nasa.gov/insitu/1.0/query_data_doms_custom_pagination'
-INSITU_API_SCHEMA_ENDPOINT = None
+INSITU_API_SCHEMA_ENDPOINT = 'https://doms.jpl.nasa.gov/in_situ_schema.json'
 
 INSITU_PROVIDER_MAP = [
     {

--- a/analysis/webservice/algorithms/doms/insitu.py
+++ b/analysis/webservice/algorithms/doms/insitu.py
@@ -29,6 +29,9 @@ def query_insitu_schema():
     metadata
     """
     schema_endpoint = insitu_endpoints.getSchemaEndpoint()
+    if schema_endpoint is None:
+        logging.warning('No insitu schema endpoint defined. Skipping.')
+        return {}
     logging.info("Querying schema")
     response = requests.get(schema_endpoint)
     response.raise_for_status()

--- a/analysis/webservice/algorithms_spark/Matchup.py
+++ b/analysis/webservice/algorithms_spark/Matchup.py
@@ -548,11 +548,11 @@ class DomsPoint(object):
             return key in d and d[key] is not None and d[key] != ''
 
         if is_defined('id', point.platform):
-            point.platform = edge_point.get('platform')['id']
+            point.platform = str(edge_point.get('platform')['id'])
         elif is_defined('code', point.platform):
-            point.platform = edge_point.get('platform')['code']
+            point.platform = str(edge_point.get('platform')['code'])
         elif is_defined('type', point.platform):
-            point.platform = edge_point.get('platform')['type']
+            point.platform = str(edge_point.get('platform')['type'])
 
         data_fields = [
             'air_pressure',


### PR DESCRIPTION
- Cast platform to string. SDAP requires platform to be a string (db col is str) but the DOMS insitu API seems to return an integer.
- Add mechanism for not supporting insitu schema. As far as I know no schema endpoint exists in DOMS, so in this case we'd set the schema endpoint to None. 
- Removed cloud insitu nodes from conf. Added DOMS insitu nodes

---

### Testing

All testing was done on a local instance of SDAP where Cass/Solr are running locally via Docker. I ingested AVHRR_OI_L4_GHRSST_NCEI 2018-08-01 - 2018-08-16 data prior to running this test.

Test query:

```bash
localhost:8083/match_spark?primary=AVHRR_OI_L4_GHRSST_NCEI&secondary=SAMOS&startTime=2018-08-01T00%3A00%3A00Z&endTime=2018-08-01T23%3A59%3A59Z&b=-122%2C%2026%2C%20-114%2C%2034&platforms=30&depthMin=-1&depthMax=1&tt=43200&rt=18750&matchOnce=true&prioritizeDistance=true
```

Job completes successfully. Results (JSON `/cdmsresults` endpoint)

```json
{
	"executionId": "fe87f866-a415-494e-851a-7a666fdfe5f3",
	"data": [{
		"platform": "orbiting satellite",
		"device": "radiometers",
		"lon": "-117.375",
		"lat": "32.625",
		"point": "Point(-117.375 32.625)",
		"time": 1533081600,
		"depth": null,
		"fileurl": "20180801120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.0.nc",
		"id": "9793ad5b-5d06-3163-95b2-b5f020280044[[0, 90, 50]]",
		"source": "AVHRR_OI_L4_GHRSST_NCEI",
		"primary": [{
			"variable_name": "analysed_sst",
			"cf_variable_name": "sea_surface_temperature",
			"variable_value": 23.899993896484375,
			"variable_unit": null
		}],
		"matches": [{
			"platform": "30",
			"device": null,
			"lon": "-117.2368",
			"lat": "32.7076",
			"point": "Point(-117.237 32.708)",
			"time": 1533081240,
			"depth": -99999,
			"fileurl": null,
			"id": "WSQ2674_20180731v20001_1434-99999.0@-99999.0",
			"source": "SAMOS",
			"secondary": [{
				"variable_name": "relative_humidity",
				"cf_variable_name": "relative_humidity",
				"variable_value": 71,
				"variable_unit": null
			}, {
				"variable_name": "relative_humidity_quality",
				"cf_variable_name": "relative_humidity_quality",
				"variable_value": 1,
				"variable_unit": null
			}, {
				"variable_name": "sea_water_temperature",
				"cf_variable_name": "sea_water_temperature",
				"variable_value": 23.2,
				"variable_unit": null
			}, {
				"variable_name": "sea_water_temperature_quality",
				"cf_variable_name": "sea_water_temperature_quality",
				"variable_value": 1,
				"variable_unit": null
			}]
		}]
	}, {
		"platform": "orbiting satellite",
		"device": "radiometers",
		"lon": "-117.125",
		"lat": "32.625",
		"point": "Point(-117.125 32.625)",
		"time": 1533081600,
		"depth": null,
		"fileurl": "20180801120000-NCEI-L4_GHRSST-SSTblend-AVHRR_OI-GLOB-v02.0-fv02.0.nc",
		"id": "9793ad5b-5d06-3163-95b2-b5f020280044[[0, 90, 51]]",
		"source": "AVHRR_OI_L4_GHRSST_NCEI",
		"primary": [{
			"variable_name": "analysed_sst",
			"cf_variable_name": "sea_surface_temperature",
			"variable_value": 24.410003662109375,
			"variable_unit": null
		}],
		"matches": [{
			"platform": "30",
			"device": null,
			"lon": "-117.2367",
			"lat": "32.7076",
			"point": "Point(-117.237 32.708)",
			"time": 1533077340,
			"depth": -99999,
			"fileurl": null,
			"id": "WSQ2674_20180731v20001_1369-99999.0@-99999.0",
			"source": "SAMOS",
			"secondary": [{
				"variable_name": "relative_humidity",
				"cf_variable_name": "relative_humidity",
				"variable_value": 72.8,
				"variable_unit": null
			}, {
				"variable_name": "relative_humidity_quality",
				"cf_variable_name": "relative_humidity_quality",
				"variable_value": 1,
				"variable_unit": null
			}, {
				"variable_name": "sea_water_temperature",
				"cf_variable_name": "sea_water_temperature",
				"variable_value": 23.2,
				"variable_unit": null
			}, {
				"variable_name": "sea_water_temperature_quality",
				"cf_variable_name": "sea_water_temperature_quality",
				"variable_value": 1,
				"variable_unit": null
			}]
		}]
	}],
	"params": {
		"primary": "AVHRR_OI_L4_GHRSST_NCEI",
		"matchup": "SAMOS",
		"startTime": 1533081600,
		"endTime": 1533167999,
		"bbox": "-122, 26, -114, 34",
		"timeTolerance": 43200,
		"radiusTolerance": 18750,
		"platforms": "30",
		"parameter": null,
		"depthMin": -1,
		"depthMax": 1
	},
	"bounds": {},
	"count": 2,
	"details": {
		"timeToComplete": 9,
		"numSecondaryMatched": 2,
		"numPrimaryMatched": 2,
		"numUniqueSecondaries": 2,
		"pageNum": 1,
		"pageSize": 1000
	}
}
```

Have not yet tested NCAR insitu endpoint. 