### PR TITLE
Fixes for /apidocs endpoint

### DIFF
--- a/analysis/webservice/apidocs/index.html
+++ b/analysis/webservice/apidocs/index.html
@@ -54,7 +54,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/apidocs/openapi.yml",
+        url: "openapi.yml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         supportedSubmitMethods: [],

--- a/analysis/webservice/apidocs/openapi.yml
+++ b/analysis/webservice/apidocs/openapi.yml
@@ -16,7 +16,7 @@
 openapi: 3.0.3
 info:
   description: The next generation cloud-based science data service platform.
-  version: 1.2.0
+  version: 1.4.0
   title: Science Data Analytics Platform (SDAP)
   license:
     name: Apache 2.0


### PR DESCRIPTION
It appears the `/apidocs` endpoint has an issue with the default yaml path being 404'd, this PR adjusts it and also corrects the SDAP version number in the openAPI spec