### PR TITLE
SDAP Helm chart: allow optional annotation for IAM role association for Spark ServiceAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Unreleased
 ### Added
+- Helm chart option to associate AWS IAM role to the SDAP Spark ServiceAccount (EKS only).
 ### Changed
 - SDAP-533: Updated Helm chart
   - Updated ingress dependency chart

--- a/helm/templates/spark-serviceaccount.yml
+++ b/helm/templates/spark-serviceaccount.yml
@@ -16,6 +16,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{ if .Values.webapp.iamRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: "{{ .Values.webapp.iamRoleArn }}"
+  {{ end }}
   name: spark-serviceaccount
 automountServiceAccountToken: true
 ---

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,6 +38,7 @@ webapp:
       cores: 1
       instances: 2
       memory: "512m"
+  iamRoleArn:
 
 ## This section deals with the ingestion components of SDAP
 ingestion:


### PR DESCRIPTION
Part of the work on #312, allows SDAP deployments to use an IAM role attached to the Spark ServiceAccount to access Zarr data in S3 without needing to store any credential data.