### PR TITLE
Solr nexusdatasets operations mutexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - SDAP-531: Tomogram/Tomogram3D: Fix bug for min/max elevation == 0
+- SDAP-540: Add mutex around Solr operations for dataset add/update/delete to fix possible concurrency issue
 ### Security
 
 ## [1.4.0] - 2024-11-04

--- a/data-access/nexustiles/backends/zarr/backend.py
+++ b/data-access/nexustiles/backends/zarr/backend.py
@@ -93,6 +93,8 @@ class ZarrBackend(AbstractTileService):
 
         self.__ds: xr.Dataset = self.__open_ds()
 
+        logger.info(f'Created zarr backend for {self._name} at {self.__path}')
+
     def __open_ds(self) -> xr.Dataset:
         if self.__store_type in ['', 'file']:
             store = self.__path

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -18,6 +18,7 @@ import json
 import logging
 import sys
 import threading
+from contextlib import nullcontext
 from datetime import datetime
 from functools import reduce, wraps
 from time import sleep
@@ -46,6 +47,18 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     datefmt="%Y-%m-%dT%H:%M:%S", stream=sys.stdout)
 logger = logging.getLogger("nexus-tile-svc")
+
+
+# TODO: Clean these up & delete accompanying debug log statements when confident SDAP-540 is resolved
+DEBUG_SL_ACQING = 'DEBUG: Acquiring solr lock '
+DEBUG_SL_ACQED = 'DEBUG: Acquired solr lock '
+DEBUG_SL_REL = 'DEBUG: Released solr lock '
+DEBUG_SLC_ACQING = 'DEBUG: Acquiring solr conn lock '
+DEBUG_SLC_ACQED = 'DEBUG: Acquired solr conn lock '
+DEBUG_SLC_REL = 'DEBUG: Released solr conn lock '
+DEBUG_DS_ACQING = 'DEBUG: Acquiring dataset lock '
+DEBUG_DS_ACQED = 'DEBUG: Acquired dataset lock '
+DEBUG_DS_REL = 'DEBUG: Released dataset lock '
 
 
 def tile_data(default_fetch=True):
@@ -103,7 +116,8 @@ def catch_not_implemented(func):
     return wrapper
 
 
-SOLR_LOCK = threading.Lock()
+SOLR_OPS_LOCK = threading.Lock()
+SOLR_CONN_LOCK = threading.Lock()
 thread_local = threading.local()
 
 
@@ -129,8 +143,11 @@ class NexusTileService:
     @staticmethod
     def __update_datasets_loop():
         while True:
+            logger.info(DEBUG_DS_ACQING + '__update_datasets_loop')
             with NexusTileService.DS_LOCK:
+                logger.debug(DEBUG_DS_ACQED + '__update_datasets_loop')
                 NexusTileService._update_datasets()
+            logger.debug(DEBUG_DS_REL + '__update_datasets_loop')
             sleep(3600)
 
     def __init__(self, config=None):
@@ -168,7 +185,9 @@ class NexusTileService:
 
     @staticmethod
     def _get_backend(dataset_s, check=True) -> AbstractTileService:
+        logger.info(DEBUG_DS_ACQING + '_get_backend')
         with NexusTileService.DS_LOCK:
+            logger.debug(DEBUG_DS_ACQED + '_get_backend')
             if dataset_s not in NexusTileService.backends:
                 logger.warning(f'Dataset {dataset_s} not currently loaded. Checking to see if it was recently'
                                f'added')
@@ -180,8 +199,8 @@ class NexusTileService:
 
             if check and not b['backend'].update():
                 raise DatasetNotFoundException(reason=f'Dataset {dataset_s} is currently inaccessible')
-
-            return b['backend']
+        logger.info(DEBUG_DS_REL + '_get_backend')
+        return b['backend']
 
 
     @staticmethod
@@ -193,7 +212,9 @@ class NexusTileService:
         if NexusTileService.ds_config.has_option("solr", "time_out"):
             solr_kwargs["timeout"] = NexusTileService.ds_config.get("solr", "time_out")
 
-        with SOLR_LOCK:
+        logger.info(DEBUG_SLC_ACQING + '_get_datasets_store')
+        with SOLR_CONN_LOCK:
+            logger.info(DEBUG_SLC_ACQED + '_get_datasets_store')
             solrcon = getattr(thread_local, 'solrcon', None)
             if solrcon is None:
                 solr_url = '%s/solr/%s' % (solr_url, solr_core)
@@ -202,10 +223,11 @@ class NexusTileService:
 
             solrcon = solrcon
 
-            return solrcon
+        logger.info(DEBUG_SLC_REL + '_get_datasets_store')
+        return solrcon
 
     @staticmethod
-    def _update_datasets():
+    def _update_datasets(solr_lock=True):
         update_logger = logging.getLogger("nexus-tile-svc.backends")
         solrcon = NexusTileService._get_datasets_store()
 
@@ -217,7 +239,17 @@ class NexusTileService:
         added_datasets = []
         dataset_docs = []
 
-        with SOLR_LOCK:
+        lock_ctx = SOLR_OPS_LOCK if solr_lock else nullcontext()
+
+        if solr_lock:
+            update_logger.info(DEBUG_SL_ACQING + '_update_datasets')
+        else:
+            update_logger.info('DEBUG: Skipping solr lock acq _update_datasets')
+        with lock_ctx:
+            if solr_lock:
+                update_logger.info(DEBUG_SL_ACQED + '_update_datasets')
+            else:
+                update_logger.info('DEBUG: Skipped solr lock acq _update_datasets')
             update_logger.info('Scanning solr for datasets')
             while True:
                 response = solrcon.search('*:*', cursorMark=next_cursor_mark, sort='id asc')
@@ -234,6 +266,11 @@ class NexusTileService:
 
                 dataset_docs.extend(response.docs)
             update_logger.info('Finished solr scan')
+
+        if solr_lock:
+            update_logger.info(DEBUG_SL_REL + '_update_datasets')
+        else:
+            update_logger.info('DEBUG: Skipped solr lock release _update_datasets')
 
         for dataset in dataset_docs:
             d_id = dataset['dataset_s']
@@ -308,7 +345,9 @@ class NexusTileService:
 
         config_dict['config'] = config
 
-        with SOLR_LOCK:
+        logger.info(DEBUG_SL_ACQING + 'user_ds_update')
+        with SOLR_OPS_LOCK:
+            logger.info(DEBUG_SL_ACQED + 'user_ds_update')
             solr.delete(id=ds['id'])
             solr.add([{
                 'id': name,
@@ -320,10 +359,15 @@ class NexusTileService:
             }])
             solr.commit()
 
-        logger.info(f'Updated dataset {name} in Solr. Updating backends')
+            logger.info(f'Updated dataset {name} in Solr. Updating backends')
 
-        with NexusTileService.DS_LOCK:
-            NexusTileService._update_datasets()
+            logger.info(DEBUG_DS_ACQING + 'user_ds_update')
+            with NexusTileService.DS_LOCK:
+                logger.info(DEBUG_DS_ACQED + 'user_ds_update')
+                NexusTileService._update_datasets(solr_lock=False)
+            logger.info(DEBUG_DS_REL + 'user_ds_update')
+
+        logger.info(DEBUG_SL_REL + 'user_ds_update')
 
         return {'success': True}
 
@@ -342,7 +386,9 @@ class NexusTileService:
             'config': config
         }
 
-        with SOLR_LOCK:
+        logger.info(DEBUG_SL_ACQING + 'user_ds_add')
+        with SOLR_OPS_LOCK:
+            logger.info(DEBUG_SL_ACQED + 'user_ds_add')
             solr.add([{
                 'id': name,
                 'dataset_s': name,
@@ -353,10 +399,17 @@ class NexusTileService:
             }])
             solr.commit()
 
-        logger.info(f'Added dataset {name} to Solr. Updating backends')
+            logger.info(f'Added dataset {name} to Solr. Updating backends')
 
-        with NexusTileService.DS_LOCK:
-            added_datasets = NexusTileService._update_datasets()
+            logger.info(DEBUG_DS_ACQING + 'user_ds_add')
+            with NexusTileService.DS_LOCK:
+                logger.info(DEBUG_DS_ACQED + 'user_ds_add')
+                added_datasets = NexusTileService._update_datasets(solr_lock=False)
+            logger.info(DEBUG_DS_REL + 'user_ds_add')
+
+        logger.info(DEBUG_DS_REL + 'user_ds_add')
+
+        logger.info(f'DEBUG: {name} in {added_datasets}: {name in added_datasets}')
 
         response = {'success': name in added_datasets}
 
@@ -381,14 +434,21 @@ class NexusTileService:
         if 'source_s' not in ds or ds['source_s'] == 'collection_config':
             raise ValueError('Provided dataset is source_s in collection config and cannot be deleted')
 
-        with SOLR_LOCK:
+        logger.info(DEBUG_SL_ACQING + 'user_ds_delete')
+        with SOLR_OPS_LOCK:
+            logger.info(DEBUG_SL_ACQED + 'user_ds_delete')
             solr.delete(id=ds['id'])
             solr.commit()
 
-        logger.info(f'Removed dataset {name} from Solr. Updating backends')
+            logger.info(f'Removed dataset {name} from Solr. Updating backends')
 
-        with NexusTileService.DS_LOCK:
-            NexusTileService._update_datasets()
+            logger.info(DEBUG_DS_ACQING + 'user_ds_delete')
+            with NexusTileService.DS_LOCK:
+                logger.info(DEBUG_DS_ACQED + 'user_ds_delete')
+                NexusTileService._update_datasets(solr_lock=False)
+            logger.info(DEBUG_DS_REL + 'user_ds_delete')
+
+        logger.info(DEBUG_SL_REL + 'user_ds_delete')
 
         return {'success': True}
 

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -215,51 +215,58 @@ class NexusTileService:
         next_cursor_mark = '*'
 
         added_datasets = []
+        dataset_docs = []
 
-        while True:
-            response = solrcon.search('*:*', cursorMark=next_cursor_mark, sort='id asc')
+        with SOLR_LOCK:
+            update_logger.info('Scanning solr for datasets')
+            while True:
+                response = solrcon.search('*:*', cursorMark=next_cursor_mark, sort='id asc')
 
-            try:
-                response_cursor_mark = response.nextCursorMark
-            except AttributeError:
-                break
+                try:
+                    response_cursor_mark = response.nextCursorMark
+                except AttributeError:
+                    break
 
-            if response_cursor_mark == next_cursor_mark:
-                break
-            else:
-                next_cursor_mark = response_cursor_mark
-
-            for dataset in response.docs:
-                d_id = dataset['dataset_s']
-                store_type = dataset.get('store_type_s', 'nexusproto')
-
-                present_datasets.add(d_id)
-
-                if d_id in NexusTileService.backends:
-                    if not NexusTileService.backends[d_id]['backend'].update(True):
-                        logger.info(f'Dataset {d_id} of type {store_type} is no longer accessible and will be removed')
-                        present_datasets.remove(d_id)
-                    continue
-
-                added_datasets.append(d_id)
-
-                if store_type == 'nexus_proto' or store_type == 'nexusproto':
-                    update_logger.info(f"Detected new nexusproto dataset {d_id}, using default nexusproto backend")
-                    NexusTileService.backends[d_id] = NexusTileService.backends[None]
-                elif store_type == 'zarr':
-                    update_logger.info(f"Detected new zarr dataset {d_id}, opening new zarr backend")
-
-                    ds_config = json.loads(dataset['config'][0])
-                    try:
-                        NexusTileService.backends[d_id] = {
-                            'backend': ZarrBackend(dataset_name=dataset['dataset_s'], **ds_config),
-                            'up': True
-                        }
-                    except NexusTileServiceException:
-                        added_datasets.pop()
+                if response_cursor_mark == next_cursor_mark:
+                    break
                 else:
-                    update_logger.warning(f'Unsupported backend {store_type} for dataset {d_id}')
+                    next_cursor_mark = response_cursor_mark
+
+                dataset_docs.extend(response.docs)
+            update_logger.info('Finished solr scan')
+
+        for dataset in dataset_docs:
+            d_id = dataset['dataset_s']
+            store_type = dataset.get('store_type_s', 'nexusproto')
+
+            present_datasets.add(d_id)
+
+            if d_id in NexusTileService.backends:
+                if not NexusTileService.backends[d_id]['backend'].update(True):
+                    logger.info(f'Dataset {d_id} of type {store_type} is no longer accessible and will be removed')
+                    present_datasets.remove(d_id)
+                continue
+
+            added_datasets.append(d_id)
+
+            if store_type == 'nexus_proto' or store_type == 'nexusproto':
+                update_logger.info(f"Detected new nexusproto dataset {d_id}, using default nexusproto backend")
+                NexusTileService.backends[d_id] = NexusTileService.backends[None]
+            elif store_type == 'zarr':
+                update_logger.info(f"Detected new zarr dataset {d_id}, opening new zarr backend")
+
+                ds_config = json.loads(dataset['config'][0])
+                try:
+                    NexusTileService.backends[d_id] = {
+                        'backend': ZarrBackend(dataset_name=dataset['dataset_s'], **ds_config),
+                        'up': True
+                    }
+                except NexusTileServiceException as e:
+                    update_logger.warning(f'Failed to add {d_id}: {e}')
                     added_datasets.pop()
+            else:
+                update_logger.warning(f'Unsupported backend {store_type} for dataset {d_id}')
+                added_datasets.pop()
 
         removed_datasets = set(NexusTileService.backends.keys()).difference(present_datasets)
 
@@ -272,6 +279,13 @@ class NexusTileService:
 
         update_logger.info(f'Finished dataset update: {len(added_datasets)} added, {len(removed_datasets)} removed, '
                            f'{len(NexusTileService.backends) - 2} total')
+        update_logger.info('New datasets:')
+        for dataset in added_datasets:
+            update_logger.info(f"  - {dataset}")
+
+        update_logger.info('Removed datasets:')
+        for dataset in removed_datasets:
+            update_logger.info(f"  - {dataset}")
 
         return added_datasets
 
@@ -294,16 +308,17 @@ class NexusTileService:
 
         config_dict['config'] = config
 
-        solr.delete(id=ds['id'])
-        solr.add([{
-            'id': name,
-            'dataset_s': name,
-            'latest_update_l': int(datetime.now().timestamp()),
-            'store_type_s': ds['store_type_s'],
-            'config': json.dumps(config_dict),
-            'source_s': 'user_added'
-        }])
-        solr.commit()
+        with SOLR_LOCK:
+            solr.delete(id=ds['id'])
+            solr.add([{
+                'id': name,
+                'dataset_s': name,
+                'latest_update_l': int(datetime.now().timestamp()),
+                'store_type_s': ds['store_type_s'],
+                'config': json.dumps(config_dict),
+                'source_s': 'user_added'
+            }])
+            solr.commit()
 
         logger.info(f'Updated dataset {name} in Solr. Updating backends')
 
@@ -327,15 +342,16 @@ class NexusTileService:
             'config': config
         }
 
-        solr.add([{
-            'id': name,
-            'dataset_s': name,
-            'latest_update_l': int(datetime.now().timestamp()),
-            'store_type_s': type,
-            'config': json.dumps(config_dict),
-            'source_s': 'user_added'
-        }])
-        solr.commit()
+        with SOLR_LOCK:
+            solr.add([{
+                'id': name,
+                'dataset_s': name,
+                'latest_update_l': int(datetime.now().timestamp()),
+                'store_type_s': type,
+                'config': json.dumps(config_dict),
+                'source_s': 'user_added'
+            }])
+            solr.commit()
 
         logger.info(f'Added dataset {name} to Solr. Updating backends')
 
@@ -365,8 +381,9 @@ class NexusTileService:
         if 'source_s' not in ds or ds['source_s'] == 'collection_config':
             raise ValueError('Provided dataset is source_s in collection config and cannot be deleted')
 
-        solr.delete(id=ds['id'])
-        solr.commit()
+        with SOLR_LOCK:
+            solr.delete(id=ds['id'])
+            solr.commit()
 
         logger.info(f'Removed dataset {name} from Solr. Updating backends')
 

--- a/data-access/nexustiles/nexustiles.py
+++ b/data-access/nexustiles/nexustiles.py
@@ -49,18 +49,6 @@ logging.basicConfig(
 logger = logging.getLogger("nexus-tile-svc")
 
 
-# TODO: Clean these up & delete accompanying debug log statements when confident SDAP-540 is resolved
-DEBUG_SL_ACQING = 'DEBUG: Acquiring solr lock '
-DEBUG_SL_ACQED = 'DEBUG: Acquired solr lock '
-DEBUG_SL_REL = 'DEBUG: Released solr lock '
-DEBUG_SLC_ACQING = 'DEBUG: Acquiring solr conn lock '
-DEBUG_SLC_ACQED = 'DEBUG: Acquired solr conn lock '
-DEBUG_SLC_REL = 'DEBUG: Released solr conn lock '
-DEBUG_DS_ACQING = 'DEBUG: Acquiring dataset lock '
-DEBUG_DS_ACQED = 'DEBUG: Acquired dataset lock '
-DEBUG_DS_REL = 'DEBUG: Released dataset lock '
-
-
 def tile_data(default_fetch=True):
     def tile_data_decorator(func):
         @wraps(func)
@@ -143,11 +131,8 @@ class NexusTileService:
     @staticmethod
     def __update_datasets_loop():
         while True:
-            logger.info(DEBUG_DS_ACQING + '__update_datasets_loop')
             with NexusTileService.DS_LOCK:
-                logger.debug(DEBUG_DS_ACQED + '__update_datasets_loop')
                 NexusTileService._update_datasets()
-            logger.debug(DEBUG_DS_REL + '__update_datasets_loop')
             sleep(3600)
 
     def __init__(self, config=None):
@@ -185,9 +170,7 @@ class NexusTileService:
 
     @staticmethod
     def _get_backend(dataset_s, check=True) -> AbstractTileService:
-        logger.info(DEBUG_DS_ACQING + '_get_backend')
         with NexusTileService.DS_LOCK:
-            logger.debug(DEBUG_DS_ACQED + '_get_backend')
             if dataset_s not in NexusTileService.backends:
                 logger.warning(f'Dataset {dataset_s} not currently loaded. Checking to see if it was recently'
                                f'added')
@@ -199,7 +182,6 @@ class NexusTileService:
 
             if check and not b['backend'].update():
                 raise DatasetNotFoundException(reason=f'Dataset {dataset_s} is currently inaccessible')
-        logger.info(DEBUG_DS_REL + '_get_backend')
         return b['backend']
 
 
@@ -212,9 +194,7 @@ class NexusTileService:
         if NexusTileService.ds_config.has_option("solr", "time_out"):
             solr_kwargs["timeout"] = NexusTileService.ds_config.get("solr", "time_out")
 
-        logger.info(DEBUG_SLC_ACQING + '_get_datasets_store')
         with SOLR_CONN_LOCK:
-            logger.info(DEBUG_SLC_ACQED + '_get_datasets_store')
             solrcon = getattr(thread_local, 'solrcon', None)
             if solrcon is None:
                 solr_url = '%s/solr/%s' % (solr_url, solr_core)
@@ -223,7 +203,6 @@ class NexusTileService:
 
             solrcon = solrcon
 
-        logger.info(DEBUG_SLC_REL + '_get_datasets_store')
         return solrcon
 
     @staticmethod
@@ -241,15 +220,7 @@ class NexusTileService:
 
         lock_ctx = SOLR_OPS_LOCK if solr_lock else nullcontext()
 
-        if solr_lock:
-            update_logger.info(DEBUG_SL_ACQING + '_update_datasets')
-        else:
-            update_logger.info('DEBUG: Skipping solr lock acq _update_datasets')
         with lock_ctx:
-            if solr_lock:
-                update_logger.info(DEBUG_SL_ACQED + '_update_datasets')
-            else:
-                update_logger.info('DEBUG: Skipped solr lock acq _update_datasets')
             update_logger.info('Scanning solr for datasets')
             while True:
                 response = solrcon.search('*:*', cursorMark=next_cursor_mark, sort='id asc')
@@ -266,11 +237,6 @@ class NexusTileService:
 
                 dataset_docs.extend(response.docs)
             update_logger.info('Finished solr scan')
-
-        if solr_lock:
-            update_logger.info(DEBUG_SL_REL + '_update_datasets')
-        else:
-            update_logger.info('DEBUG: Skipped solr lock release _update_datasets')
 
         for dataset in dataset_docs:
             d_id = dataset['dataset_s']
@@ -345,9 +311,7 @@ class NexusTileService:
 
         config_dict['config'] = config
 
-        logger.info(DEBUG_SL_ACQING + 'user_ds_update')
         with SOLR_OPS_LOCK:
-            logger.info(DEBUG_SL_ACQED + 'user_ds_update')
             solr.delete(id=ds['id'])
             solr.add([{
                 'id': name,
@@ -361,13 +325,8 @@ class NexusTileService:
 
             logger.info(f'Updated dataset {name} in Solr. Updating backends')
 
-            logger.info(DEBUG_DS_ACQING + 'user_ds_update')
             with NexusTileService.DS_LOCK:
-                logger.info(DEBUG_DS_ACQED + 'user_ds_update')
                 NexusTileService._update_datasets(solr_lock=False)
-            logger.info(DEBUG_DS_REL + 'user_ds_update')
-
-        logger.info(DEBUG_SL_REL + 'user_ds_update')
 
         return {'success': True}
 
@@ -386,9 +345,7 @@ class NexusTileService:
             'config': config
         }
 
-        logger.info(DEBUG_SL_ACQING + 'user_ds_add')
         with SOLR_OPS_LOCK:
-            logger.info(DEBUG_SL_ACQED + 'user_ds_add')
             solr.add([{
                 'id': name,
                 'dataset_s': name,
@@ -401,15 +358,8 @@ class NexusTileService:
 
             logger.info(f'Added dataset {name} to Solr. Updating backends')
 
-            logger.info(DEBUG_DS_ACQING + 'user_ds_add')
             with NexusTileService.DS_LOCK:
-                logger.info(DEBUG_DS_ACQED + 'user_ds_add')
                 added_datasets = NexusTileService._update_datasets(solr_lock=False)
-            logger.info(DEBUG_DS_REL + 'user_ds_add')
-
-        logger.info(DEBUG_DS_REL + 'user_ds_add')
-
-        logger.info(f'DEBUG: {name} in {added_datasets}: {name in added_datasets}')
 
         response = {'success': name in added_datasets}
 
@@ -434,21 +384,14 @@ class NexusTileService:
         if 'source_s' not in ds or ds['source_s'] == 'collection_config':
             raise ValueError('Provided dataset is source_s in collection config and cannot be deleted')
 
-        logger.info(DEBUG_SL_ACQING + 'user_ds_delete')
         with SOLR_OPS_LOCK:
-            logger.info(DEBUG_SL_ACQED + 'user_ds_delete')
             solr.delete(id=ds['id'])
             solr.commit()
 
             logger.info(f'Removed dataset {name} from Solr. Updating backends')
 
-            logger.info(DEBUG_DS_ACQING + 'user_ds_delete')
             with NexusTileService.DS_LOCK:
-                logger.info(DEBUG_DS_ACQED + 'user_ds_delete')
                 NexusTileService._update_datasets(solr_lock=False)
-            logger.info(DEBUG_DS_REL + 'user_ds_delete')
-
-        logger.info(DEBUG_SL_REL + 'user_ds_delete')
 
         return {'success': True}
 


### PR DESCRIPTION
Add mutexing around Solr operations for zarr dataset add/update/delete API operations and the internal dataset refresh Solr scan. With this I hope to address a possible concurrency issue where a Solr document is deleted while the refresh scan is running, which can happen when batch updating dynamic Zarr collections in the pattern established in the Coastal Zone DT project for keep-up ingest of data.